### PR TITLE
Adding required http header to the request example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The CLSI is based on a JSON API.
 (Note that valid JSON should not contain any comments like the example below).
 
     POST /project/<project-id>/compile
+    Content-Type: application/json
 
 ```javascript
 {


### PR DESCRIPTION
The request will not be read as json if the Content-Type header is not specified,
so the server fails with the message "top level object should have a compile attribute".
