### PR TITLE
Let synctex be run locally

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -250,11 +250,11 @@ module.exports = CompileManager =
 		directory = getCompileDir(project_id, user_id)
 		timeout = 60 * 1000 # increased to allow for large projects
 		compileName = getCompileName(project_id, user_id)
-		CommandRunner.run compileName, command, directory, Settings.clsi.docker.image, timeout, {}, (error, output) ->
+		CommandRunner.run compileName, command, directory, Settings.clsi?.docker.image, timeout, {}, (error, output) ->
 			if error?
 				logger.err err:error, command:command, project_id:project_id, user_id:user_id, "error running synctex"
 				return callback(error)
-			callback(null, output.stdout)
+			callback(null, output?.stdout)
 
 	_parseSynctexFromCodeOutput: (output) ->
 		results = []

--- a/app/coffee/LocalCommandRunner.coffee
+++ b/app/coffee/LocalCommandRunner.coffee
@@ -4,9 +4,9 @@ logger = require "logger-sharelatex"
 logger.info "using standard command runner"
 
 module.exports = CommandRunner =
-	run: (project_id, command, directory, image, timeout, environment, callback = (error) ->) ->
-		command = (arg.replace('$COMPILE_DIR', directory) for arg in command)
+	run: (project_id, command, directory, image, timeout, environment, callback = (error, output) ->) ->
 		logger.log project_id: project_id, command: command, directory: directory, "running command"
+		command = ((if arg.replace? then arg.replace('$COMPILE_DIR', directory) else arg) for arg in command)
 		logger.warn "timeouts and sandboxing are not enabled with CommandRunner"
 
 		# merge environment settings
@@ -14,8 +14,20 @@ module.exports = CommandRunner =
 		env[key] = value for key, value of process.env
 		env[key] = value for key, value of environment
 
+		output = { stdout: "", stderr: "" }
+
 		# run command as detached process so it has its own process group (which can be killed if needed)
-		proc = spawn command[0], command.slice(1), stdio: "inherit", cwd: directory, detached: true, env: env
+		proc = spawn command[0], command.slice(1), stdio: ["inherit", "pipe", "pipe"], cwd: directory, detached: true, env: env
+
+		proc.stdout.setEncoding 'utf8'
+		proc.stdout.on 'data', (data) ->
+			console.log data
+			output.stdout = output.stdout.concat data
+
+		proc.stderr.setEncoding 'utf8'
+		proc.stderr.on 'data', (data) ->
+			console.error data
+			output.stderr = output.stderr.concat data
 
 		proc.on "error", (err)->
 			logger.err err:err, project_id:project_id, command: command, directory: directory, "error running command"
@@ -26,13 +38,13 @@ module.exports = CommandRunner =
 			if signal is 'SIGTERM' # signal from kill method below
 				err = new Error("terminated")
 				err.terminated = true
-				return callback(err)
+				return callback(err, output)
 			else if code is 1 # exit status from chktex
 				err = new Error("exited")
 				err.code = code
-				return callback(err)
+				return callback(err, output)
 			else
-				callback()
+				callback(null, output)
 
 		return proc.pid # return process id to allow job to be killed if necessary
 

--- a/app/coffee/LocalCommandRunner.coffee
+++ b/app/coffee/LocalCommandRunner.coffee
@@ -19,6 +19,7 @@ module.exports = CommandRunner =
 		# run command as detached process so it has its own process group (which can be killed if needed)
 		proc = spawn command[0], command.slice(1), stdio: ["inherit", "pipe", "pipe"], cwd: directory, detached: true, env: env
 
+		# places for the output pipes to connect to
 		proc.stdout.setEncoding 'utf8'
 		proc.stdout.on 'data', (data) ->
 			console.log data


### PR DESCRIPTION
Currently, clsi fails (and crashes) when it attempts to run synctex through LocalCommandRunner. This fixes that, so long as the provided synctex binary is in /opt