### PR TITLE
[docker] add support for a different docker group id on the docker host

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,10 @@ echo "Changing permissions of /var/run/docker.sock for sibling containers"
 ls -al /var/run/docker.sock
 docker --version
 cat /etc/passwd
-usermod -aG docker node
-chown root:docker /var/run/docker.sock
+
+DOCKER_GROUP=$(stat -c '%g' /var/run/docker.sock)
+groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost
+usermod -aG dockeronhost node
 
 mkdir -p /app/cache
 chown -R node:node /app/cache


### PR DESCRIPTION
The docker unix-group on the host running the docker container may have a different id than the group in the container. Changing the ownership/group of the docker socket may kill the access on the socket for non-root users on the docker host.

The group id varies per distribution and is easy to detect via stat call on the socket.

As the docker group may actually match in both environments we must add the new group gracefully via the `--non-unique` flag.