### PR TITLE
[docker] install qpdf

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,4 +1,8 @@
 /bin/sh
 wget -qO- https://get.docker.com/ | sh
-apt-get install poppler-utils vim ghostscript --yes
+apt-get install \
+    poppler-utils \
+    ghostscript \
+    qpdf \
+    --yes
 npm rebuild


### PR DESCRIPTION
`qpdf` is required for the pdf-optimizations.

---

Note: I dropped `vim`, which is not needed in a backend container. There is always the `--volumes-from` flag. In addition this method does not require the backend container to run for peeking into its content.