### PR TITLE
[ExampleDocumentTests] drop out in case of an error during compilation

### DIFF
--- a/test/acceptance/js/ExampleDocumentTests.js
+++ b/test/acceptance/js/ExampleDocumentTests.js
@@ -235,6 +235,7 @@ describe('Example Documents', function() {
                 ) === 'failure'
               ) {
                 console.log('DEBUG: error', error, 'body', JSON.stringify(body))
+                return done(new Error("Compile failed"))
               }
               const pdf = Client.getOutputFile(body, 'pdf')
               return downloadAndComparePdf(
@@ -263,6 +264,7 @@ describe('Example Documents', function() {
                 ) === 'failure'
               ) {
                 console.log('DEBUG: error', error, 'body', JSON.stringify(body))
+                return done(new Error("Compile failed"))
               }
               const pdf = Client.getOutputFile(body, 'pdf')
               return downloadAndComparePdf(


### PR DESCRIPTION
We are already detecting the failure of the compilation, let's raise it immediately after logging.

There is no need to move on and fail with a random access error:

`Client.getOutputFile` will likely return `pdf = null` and `pdf.url` will error out.

<details>
  <summary>Error before applying the patch</summary>

  <pre>
  13) Example Documents
       knitr
         should generate the correct pdf:
     Uncaught TypeError: Cannot read property 'url' of null
      at Request._callback (test/acceptance/js/ExampleDocumentTests.js:214:79)
      at Request.self.callback (node_modules/request/request.js:185:22)
      at Request.<anonymous> (node_modules/request/request.js:1161:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
      at endReadableNT (_stream_readable.js:1094:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
  </pre>
</details>


<details>
  <summary>Error after applying the patch</summary>

  <pre>
  13) Example Documents
       knitr
         should generate the correct pdf:
     Uncaught AssertionError: Compile failed
  </pre>
</details>

