### PR TITLE
Increase the hard-timeout to 10 minutes.

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -34,7 +34,7 @@ app.use Metrics.http.monitor(logger)
 # Compile requests can take longer than the default two
 # minutes (including file download time), so bump up the 
 # timeout a bit.
-TIMEOUT = 6 * 60 * 1000
+TIMEOUT = 10 * 60 * 1000
 app.use (req, res, next) ->
 	req.setTimeout TIMEOUT
 	res.setTimeout TIMEOUT

--- a/app/coffee/RequestParser.coffee
+++ b/app/coffee/RequestParser.coffee
@@ -2,7 +2,7 @@ settings = require("settings-sharelatex")
 
 module.exports = RequestParser =
 	VALID_COMPILERS: ["pdflatex", "latex", "xelatex", "lualatex"]
-	MAX_TIMEOUT: 300
+	MAX_TIMEOUT: 600
 
 	parse: (body, callback = (error, data) ->) ->
 		response = {}


### PR DESCRIPTION
In practice most projects will still be limited to five minutes,
but this allows us to bump up the limit for some projects,
especially legacy v1 projects that have been imported to v2

As far as I can tell, this is the last bottleneck in the call-stack where the timeout was being clamped to below ten minutes.


#### Related Issues / PRs

- Connects to https://github.com/overleaf/issues/issues/1308


#### Potential Impact

- Allowing some projects to compile for longer, maybe increasing load on some instances?


#### Manual Testing Performed

- [x] tested with an infinite loop, and setting the timeout to 9:30



#### Who Needs to Know?


@overleaf/support @henryoswald @jdleesmiller @mans0954 