### PR TITLE
Ensure URL cache dir exists before writing to it

### DIFF
--- a/test/unit/coffee/UrlCacheTests.coffee
+++ b/test/unit/coffee/UrlCacheTests.coffee
@@ -130,7 +130,11 @@ describe "UrlCache", ->
 			@destPath = "path/to/destination"
 			@UrlCache._copyFile = sinon.stub().callsArg(2)
 			@UrlCache._ensureUrlIsInCache = sinon.stub().callsArgWith(3, null, @cachePath)
+			@UrlCache._ensureCacheDirExists = sinon.stub().callsArg(0)
 			@UrlCache.downloadUrlToFile(@project_id, @url, @destPath, @lastModified, @callback)
+
+		it "should ensure that the cache exists", ->
+			sinon.assert.called(@UrlCache._ensureCacheDirExists)
 
 		it "should ensure the URL is downloaded and updated in the cache", ->
 			@UrlCache._ensureUrlIsInCache


### PR DESCRIPTION
### Description

This ensures that the URL cache directory, `Settings.path.clsiCacheDir`, exists before it is used.

This directory can sometimes not be present in the development environment, and breaks compiles when this is the case. This patch ensures that the directory will always be present.

### Review

Shouldn't be too controversial I hope. Causes an extra disk read on compile, but this is not going to be the bottleneck here.

When this directory goes missing (or isn't created) in a dockerised development environment, this can lead to difficult-to-track-down compile failures.

- [x] Compile things
- [x] Remove the cache directory and compile more things
