### PR TITLE
Fix synctex for LocalCommandRunner

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -250,7 +250,7 @@ module.exports = CompileManager =
 		directory = getCompileDir(project_id, user_id)
 		timeout = 60 * 1000 # increased to allow for large projects
 		compileName = getCompileName(project_id, user_id)
-		CommandRunner.run compileName, command, directory, Settings.clsi.docker.image, timeout, {}, (error, output) ->
+		CommandRunner.run compileName, command, directory, Settings.clsi?.docker.image, timeout, {}, (error, output) ->
 			if error?
 				logger.err err:error, command:command, project_id:project_id, user_id:user_id, "error running synctex"
 				return callback(error)


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

I ran sharelatex/sharelatex:2.0-beta-2 using the [docker-compose.yml](https://github.com/overleaf/overleaf/blob/66c8f0a14ce01ddaa7c9123450d13ec1c3602b85/docker-compose.yml), just edited the image to `sharelatex/sharelatex:2.0-beta-2`.

I didn't use DOCKER_RUNNER and SANDBOXED_COMPILES.

I got 3 errors when I sync between TeX and PDF:

1. Undefined Settings.clsi.docker in CompileManager.js
2. Numbers were not converted to string in LocalCommandRunner.js
3. `stdout` was not sent to callback in LocalCommandRunner.js.

Further, `/opt/synctex` does not exist in the image `sharelatex/sharelatex:2.0-beta-2`, run `ln -s /var/www/sharelatex/clsi/bin/synctex /opt/synctex` could fix the issue.

This pull request fixes the errors, and then we can sync between TeX and PDF without DOCKER_RUNNER.

#### Screenshots

Error 1

```
/var/www/sharelatex/clsi/app/js/CompileManager.js:449
      return CommandRunner.run(compileName, command, directory, Settings.clsi.docker.image, timeout, {}, function(error, output) {
                                                                              ^

TypeError: Cannot read property 'docker' of undefined
    at Object._runSynctex (/var/www/sharelatex/clsi/app/js/CompileManager.js:449:79)
    at /var/www/sharelatex/clsi/app/js/CompileManager.js:395:31
    at /var/www/sharelatex/clsi/node_modules/fs-extra/lib/mkdir.js:48:16
    at FSReqWrap.oncomplete (fs.js:154:5)
```

Error 2

```
/var/www/sharelatex/clsi/app/js/LocalCommandRunner.js:23
          _results.push(arg.replace('$COMPILE_DIR', directory));
                            ^

TypeError: arg.replace is not a function
    at /var/www/sharelatex/clsi/app/js/LocalCommandRunner.js:23:29
    at Object.run (/var/www/sharelatex/clsi/app/js/LocalCommandRunner.js:26:9)
    at Object._runSynctex (/var/www/sharelatex/clsi/app/js/CompileManager.js:449:28)
    at /var/www/sharelatex/clsi/app/js/CompileManager.js:395:31
    at /var/www/sharelatex/clsi/node_modules/fs-extra/lib/mkdir.js:48:16
    at FSReqWrap.oncomplete (fs.js:154:5)
```

Error 3

```
/var/www/sharelatex/clsi/app/js/CompileManager.js:459
        return callback(null, output.stdout);
                                     ^

TypeError: Cannot read property 'stdout' of undefined
    at /var/www/sharelatex/clsi/app/js/CompileManager.js:459:38
    at ChildProcess.<anonymous> (/var/www/sharelatex/clsi/app/js/LocalCommandRunner.js:74:18)
    at ChildProcess.emit (events.js:198:13)
    at maybeClose (internal/child_process.js:982:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
```
