### PR TITLE
[LocalCommandRunner] run: block a double call of the callback

### DIFF
--- a/app/js/LocalCommandRunner.js
+++ b/app/js/LocalCommandRunner.js
@@ -15,6 +15,7 @@
  */
 let CommandRunner
 const { spawn } = require('child_process')
+const _ = require('underscore')
 const logger = require('logger-sharelatex')
 
 logger.info('using standard command runner')
@@ -24,6 +25,8 @@ module.exports = CommandRunner = {
     let key, value
     if (callback == null) {
       callback = function(error) {}
+    } else {
+      callback = _.once(callback)
     }
     command = Array.from(command).map(arg =>
       arg.toString().replace('$COMPILE_DIR', directory)


### PR DESCRIPTION
### Description
_Given that you are still supporting the local runner (#131), this might be of interest too._

The subprocess event handler fires the "error" and "close" event in case
 of a failure.
Both events would call the given callback, resulting in double
 processing of the subprocess result downstream.

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
