### PR TITLE
Send output files on timeout

### DIFF
--- a/app/coffee/CompileManager.coffee
+++ b/app/coffee/CompileManager.coffee
@@ -106,10 +106,11 @@ module.exports = CompileManager =
 						error = new Error("compilation")
 						error.validate = "fail"
 					# compile was killed by user, was a validation, or a compile which failed validation
-					if error?.terminated or error?.validate
+					if error?.terminated or error?.validate or error?.timedout
 						OutputFileFinder.findOutputFiles resourceList, compileDir, (err, outputFiles) ->
 							return callback(err) if err?
-							callback(error, outputFiles) # return output files so user can check logs
+							error.outputFiles = outputFiles  # return output files so user can check logs
+							callback(error)
 						return
 					# compile completed normally
 					return callback(error) if error?

--- a/app/coffee/DockerRunner.coffee
+++ b/app/coffee/DockerRunner.coffee
@@ -78,7 +78,7 @@ module.exports = DockerRunner =
 			_callback(args...)
 			# Only call the callback once
 			_callback = () ->
-		
+
 		name = options.name
 
 		streamEnded = false
@@ -115,7 +115,7 @@ module.exports = DockerRunner =
 
 	_getContainerOptions: (command, image, volumes, timeout, environment) ->
 		timeoutInSeconds = timeout / 1000
-		
+
 		dockerVolumes = {}
 		for hostVol, dockerVol of volumes
 			dockerVolumes[dockerVol] = {}
@@ -148,7 +148,7 @@ module.exports = DockerRunner =
 				"Ulimits": [{'Name': 'cpu', 'Soft': timeoutInSeconds+5, 'Hard': timeoutInSeconds+10}]
 				"CapDrop": "ALL"
 				"SecurityOpt": ["no-new-privileges"]
-		
+
 
 		if Settings.path?.synctexBinHostPath?
 			options["HostConfig"]["Binds"].push("#{Settings.path.synctexBinHostPath}:/opt/synctex:ro")
@@ -276,7 +276,7 @@ module.exports = DockerRunner =
 			logger.log container_id: containerId, "timeout reached, killing container"
 			container.kill(() ->)
 		, timeout
-			
+
 		logger.log container_id: containerId, "waiting for docker container"
 		container.wait (error, res) ->
 			if error?

--- a/test/acceptance/coffee/TimeoutTests.coffee
+++ b/test/acceptance/coffee/TimeoutTests.coffee
@@ -15,7 +15,7 @@ describe "Timed out compile", ->
 					\\documentclass{article}
 					\\begin{document}
 					\\def\\x{Hello!\\par\\x}
-					\\x					
+					\\x
 					\\end{document}
 				'''
 			]
@@ -29,3 +29,6 @@ describe "Timed out compile", ->
 	it "should return a timedout status", ->
 		@body.compile.status.should.equal "timedout"
 
+	it "should return the log output file name", ->
+		outputFilePaths = @body.compile.outputFiles.map((x) => x.path)
+		outputFilePaths.should.include('output.log')


### PR DESCRIPTION
### Description

The unconventional use of callbacks to return both an error and data
after compilation created a subtle bug where the output files were
dropped by the LockManager in case of an error such as a timeout.

This prevented the frontend to show error logs when a timeout occurs,
creating confusion among users.

We now attach the output files to the error so that they reach the
controller and are sent back to the web service.

#### Screenshots

![timeout1](https://user-images.githubusercontent.com/5454374/67329079-59576300-f4e8-11e9-8a28-42f118d1bd7f.png)
![timeout2](https://user-images.githubusercontent.com/5454374/67329089-5c525380-f4e8-11e9-8e1e-02f4db159f68.png)


#### Related Issues / PRs

Issue: overleaf/issues#1286

### Review



#### Potential Impact

This will also make output files and logs available when you manually stop a compile.

#### Manual Testing Performed

- [x] Compile a problematic document that usually triggers a timeout
- [x] Manually stop a compile
