### PR TITLE
Show output files in subfolders

### DIFF
--- a/app/coffee/OutputCacheManager.coffee
+++ b/app/coffee/OutputCacheManager.coffee
@@ -65,7 +65,7 @@ module.exports = OutputCacheManager =
 				async.mapSeries outputFiles, (file, cb) ->
 					# don't send dot files as output, express doesn't serve them
 					if OutputCacheManager._fileIsHidden(file.path)
-						logger.warn compileDir: compileDir, path: file.path, "ignoring dotfile in output"
+						logger.debug compileDir: compileDir, path: file.path, "ignoring dotfile in output"
 						return cb()
 					# copy other files into cache directory if valid
 					newFile = _.clone(file)
@@ -150,7 +150,7 @@ module.exports = OutputCacheManager =
 			, callback
 
 	_fileIsHidden: (path) ->
-		return path?.match(/^\.|\/./)?
+		return path?.match(/^\.|\/\./)?
 
 	_checkFileIsSafe: (src, callback = (error, isSafe) ->) ->
 		# check if we have a valid file to copy into the cache


### PR DESCRIPTION
### Description

This fixes a tiny regexp bug that prevents output files in subfolders
from being shown in the "Other logs & files" panel.

We also downgrade the corresponding log because it's very noisy and does
not indicate a problem.

#### Screenshots

![subfolder](https://user-images.githubusercontent.com/5454374/68393002-06f98180-0139-11ea-9b2e-2a1fa75d4d0a.png)

#### Related Issues / PRs

I stumbled upon that while looking at noisy logs (https://github.com/overleaf/issues/issues/2470)

### Review

This looks like a bug, but maybe it was intentional. I'd like to have other opinions on the matter.

#### Potential Impact

This will increase the number of output files returned by CLSI, which could increase the storage demands on the CLSI output cache. It will also exacerbate an existing problem in the UI with long output file names.

![long-folder](https://user-images.githubusercontent.com/5454374/68393784-b5ea8d00-013a-11ea-92bf-99a0de18a17b.png)

#### Manual Testing Performed

- [x] Produce an output file in a subfolder 
