### PR TITLE
[DockerRunner] destroyOldContainers: normalize the container name

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -632,6 +632,9 @@ module.exports = DockerRunner = {
             ttl
           ) {
             if (name.slice(0, 9) === '/project-' && ttl <= 0) {
+              // strip the / prefix
+              // the LockManager uses the plain container name
+              name = name.slice(1)
               return jobs.push(cb =>
                 DockerRunner.destroyContainer(name, id, false, () => cb())
               )

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -630,19 +630,19 @@ describe('DockerRunner', function() {
     it('should destroy old containers', function() {
       this.DockerRunner.destroyContainer.callCount.should.equal(1)
       return this.DockerRunner.destroyContainer
-        .calledWith('/project-old-container-name', 'old-container-id')
+        .calledWith('project-old-container-name', 'old-container-id')
         .should.equal(true)
     })
 
     it('should not destroy new containers', function() {
       return this.DockerRunner.destroyContainer
-        .calledWith('/project-new-container-name', 'new-container-id')
+        .calledWith('project-new-container-name', 'new-container-id')
         .should.equal(false)
     })
 
     it('should not destroy non-project containers', function() {
       return this.DockerRunner.destroyContainer
-        .calledWith('/totally-not-a-project-container', 'some-random-id')
+        .calledWith('totally-not-a-project-container', 'some-random-id')
         .should.equal(false)
     })
 


### PR DESCRIPTION
### Description

The docker api returns each name with a `/` prefix.

In order to not interfere with pending compiles, the deletion process
 has to acquire an internal lock on the container. The LockManager uses
 the plain container name without the slash: `project-xxx` [1].

#### Screenshots

<details>
<summary> error log message caused by the missing lock </summary>

https://github.com/overleaf/clsi/blob/f285e08ee055e7b0fc0c81d598a61f40cfdebeb4/app/coffee/DockerRunner.coffee#L315
```json
{
  "container_id": "fe66435f9...",
  "err": {
    "json": {
      "message": "You cannot remove a running container fe66435f9.... Stop the container before attempting removal or force remove"
    },
    "message": "(HTTP code 409) unexpected - You cannot r...",
    "name": "Error",
    "stack": "...",
    "statusCode": 409
  },
  "msg": "error destroying container"
}
```
</details>



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?

---
[1]: https://github.com/overleaf/clsi/blob/f285e08ee055e7b0fc0c81d598a61f40cfdebeb4/app/coffee/DockerRunner.coffee#L47 -> https://github.com/overleaf/clsi/blob/f285e08ee055e7b0fc0c81d598a61f40cfdebeb4/app/coffee/DockerRunner.coffee#L166-L167
