### PR TITLE
Upgrade to local node:10.18.1 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.0 as app
+FROM gcr.io/overleaf-ops/node:10.18.1 as app
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY . /app
 
 RUN npm run compile:all
 
-FROM node:10.15.0
+FROM gcr.io/overleaf-ops/node:10.18.1
 
 COPY --from=app /app /app
 


### PR DESCRIPTION
### Description

Upgrade to a locally built node 10.18.1 base image. This is in preparation for another upgrade later.

#### Related Issues / PRs

overleaf/issues#2705

#### Potential Impact

This upgrades node from 10.15.0 to 10.18.1. We should try it out in staging first, then monitor a bit when it goes to prod.

#### Who Needs to Know?

The ops team