### PR TITLE
support other runtimes

### DIFF
--- a/app/coffee/DockerRunner.coffee
+++ b/app/coffee/DockerRunner.coffee
@@ -149,9 +149,11 @@ module.exports = DockerRunner =
 				"CapDrop": "ALL"
 				"SecurityOpt": ["no-new-privileges"]
 
-
 		if Settings.path?.synctexBinHostPath?
 			options["HostConfig"]["Binds"].push("#{Settings.path.synctexBinHostPath}:/opt/synctex:ro")
+
+		if Settings.clsi.docker.runtime?
+			options["HostConfig"]["Runtime"] = Settings.clsi.docker.runtime
 
 		if Settings.clsi.docker.seccomp_profile?
 			options.HostConfig.SecurityOpt.push "seccomp=#{Settings.clsi.docker.seccomp_profile}"

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -50,6 +50,7 @@ if process.env["DOCKER_RUNNER"]
 	module.exports.clsi =
 		dockerRunner: process.env["DOCKER_RUNNER"] == "true"
 		docker:
+			runtime: process.env["DOCKER_RUNTIME"]
 			image: process.env["TEXLIVE_IMAGE"] or "quay.io/sharelatex/texlive-full:2017.1"
 			env:
 				HOME: "/tmp"


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Allow other docker runtimes.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2458

### Review

Small change,  adds an optional `Runtime` parameter to the `HostConfig` https://docs.docker.com/engine/api/v1.30/#operation/ContainerCreate


#### Potential Impact

Low

#### Manual Testing Performed

- [X]   Test in dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?
