### PR TITLE
copy synctex over to /app/bin/synctex-mount in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,6 @@ chown -R node:node /app
 
 chown -R node:node /app/bin
 
+cp /app/bin/synctex /app/bin/synctex-mount/synctex
+
 exec runuser -u node -- "$@"


### PR DESCRIPTION
was removed as part of https://github.com/overleaf/clsi/pull/152, copying synctex still required, should be tested in stag