### PR TITLE
[misc] add a metric for failing downloads

### DIFF
--- a/app/js/ResourceWriter.js
+++ b/app/js/ResourceWriter.js
@@ -324,6 +324,7 @@ module.exports = ResourceWriter = {
                   },
                   'error downloading file for resources'
                 )
+                Metrics.inc('download-failed')
               }
               return callback()
             }

--- a/test/unit/js/ResourceWriterTests.js
+++ b/test/unit/js/ResourceWriterTests.js
@@ -36,6 +36,7 @@ describe('ResourceWriter', function() {
         './OutputFileFinder': (this.OutputFileFinder = {}),
         'logger-sharelatex': { log: sinon.stub(), err: sinon.stub() },
         './Metrics': (this.Metrics = {
+          inc: sinon.stub(),
           Timer: (Timer = (function() {
             Timer = class Timer {
               static initClass() {


### PR DESCRIPTION
### Description

This could have helped us in detecting todays failure on a per node basis.

Also we are able to set an alert trigger for the future.

#### Potential Impact

Low.


#### Manual Testing Performed

- unit and acceptance tests pass locally


#### Metrics and Monitoring

`download_failed`

