### PR TITLE
[misc] entry point cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ gitrev
 .npm
 .nvmrc
 nodemon.json
+db/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,6 @@ gitrev
 .npm
 .nvmrc
 nodemon.json
+cache/
+compiles/
 db/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY . /app
 FROM base
 
 COPY --from=app /app /app
-RUN mkdir -p db \
-&&  chown node:node db
+RUN mkdir -p cache compiles db \
+&&  chown node:node cache compiles db
 
 CMD ["node", "--expose-gc", "app.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ COPY . /app
 FROM base
 
 COPY --from=app /app /app
+RUN mkdir -p db \
+&&  chown node:node db
 
 CMD ["node", "--expose-gc", "app.js"]

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -1,6 +1,6 @@
 clsi
 --acceptance-creds=None
---data-dirs=db
+--data-dirs=cache,compiles,db
 --dependencies=
 --docker-repos=gcr.io/overleaf-ops
 --env-add=

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -1,5 +1,6 @@
 clsi
 --acceptance-creds=None
+--data-dirs=db
 --dependencies=
 --docker-repos=gcr.io/overleaf-ops
 --env-add=

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -9,7 +9,7 @@ module.exports = {
       username: 'clsi',
       dialect: 'sqlite',
       storage:
-        process.env.SQLITE_PATH || Path.resolve(__dirname + '/../db.sqlite'),
+        process.env.SQLITE_PATH || Path.resolve(__dirname + '/../db/db.sqlite'),
       pool: {
         max: 1,
         min: 1
@@ -65,8 +65,7 @@ if (process.env.DOCKER_RUNNER) {
     dockerRunner: process.env.DOCKER_RUNNER === 'true',
     docker: {
       image:
-        process.env.TEXLIVE_IMAGE ||
-        'quay.io/sharelatex/texlive-full:2017.1',
+        process.env.TEXLIVE_IMAGE || 'quay.io/sharelatex/texlive-full:2017.1',
       env: {
         HOME: '/tmp'
       },
@@ -93,8 +92,7 @@ if (process.env.DOCKER_RUNNER) {
 
   module.exports.path.synctexBaseDir = () => '/compile'
 
-  module.exports.path.sandboxedCompilesHostDir =
-    process.env.COMPILES_HOST_DIR
+  module.exports.path.sandboxedCompilesHostDir = process.env.COMPILES_HOST_DIR
 
   module.exports.path.synctexBinHostPath = process.env.SYNCTEX_BIN_HOST_PATH
 }

--- a/db/.gitignore
+++ b/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-echo "Changing permissions of /var/run/docker.sock for sibling containers"
-ls -al /var/run/docker.sock
-docker --version
-cat /etc/passwd
+docker --version >&2
 
 DOCKER_GROUP=$(stat -c '%g' /var/run/docker.sock)
 groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,10 +12,6 @@ chown node:node /app/cache
 chown node:node /app/compiles
 chown node:node /app/db
 
-# acceptance tests
-mkdir -p /app/test/acceptance/fixtures/tmp/
-chown -R node:node /app/test/acceptance/fixtures
-
 # make synctex available for remount in compiles
 cp /app/bin/synctex /app/bin/synctex-mount/synctex
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,22 +2,21 @@
 
 docker --version >&2
 
+# add the node user to the docker group on the host
 DOCKER_GROUP=$(stat -c '%g' /var/run/docker.sock)
 groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost
 usermod -aG dockeronhost node
 
-mkdir -p /app/cache
-chown -R node:node /app/cache
+# compatibility: initial volume setup
+chown node:node /app/cache
+chown node:node /app/compiles
+chown node:node /app/db
 
-mkdir -p /app/compiles
-chown -R node:node /app/compiles
-
-chown -R node:node /app/bin/synctex
+# acceptance tests
 mkdir -p /app/test/acceptance/fixtures/tmp/
-chown -R node:node /app
+chown -R node:node /app/test/acceptance/fixtures
 
-chown -R node:node /app/bin
-
+# make synctex available for remount in compiles
 cp /app/bin/synctex /app/bin/synctex-mount/synctex
 
 exec runuser -u node -- "$@"


### PR DESCRIPTION
### Description

Use the new `data-dirs` approach in the build-scripts for marking directories as writable for the run-time user.

The run user will be able to write here:

- /app/cache
- /app/compiles
- /app/db
- for tests in some test/acceptance directory -- there is no need to flag this as a volume.

Changing the ownership is a massive performance hit for the startup.
With that removed, expect that boxes come up much faster.

### Review

Prettier was complaining about the line length in the settings defaults.

~There is a race condition in CI, cloud-builder would run `test_clean` -- a prerequisite from `test_acceptance` -- and try to clean the `test_unit` container. The commit https://github.com/overleaf/clsi/commit/f30f4ab96ebcecfdbe2f2f0f725deb08145ce0d5 fixes that in putting the two invocations into two namespaces -- it needs to be ported to build-scripts next.~ Fixed in #160

#### Potential Impact

High.


#### Manual Testing Performed

- ci runs a bunch of compiles.

#### Deployment Checklist

- [ ] Run in staging and verify permissions in a pod -- see above what should be owned by `node` --, just to make sure we run the latest version

#### Future

Remove the chown calls from the entry-point and put them into the start-up script.