### PR TITLE
[misc] keep up with the error signature of dockerode/docker-modem

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -99,11 +99,7 @@ module.exports = DockerRunner = {
       error,
       output
     ) {
-      if (
-        __guard__(error != null ? error.message : undefined, x =>
-          x.match('HTTP code is 500')
-        )
-      ) {
+      if (error && error.statusCode === 500) {
         logger.log(
           { err: error, project_id },
           'error running container so destroying and retrying'

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -202,9 +202,9 @@ describe('DockerRunner', function() {
           }
           if (firstTime) {
             firstTime = false
-            return callback(
-              new Error('HTTP code is 500 which indicates error: server error')
-            )
+            const error = new Error('(HTTP code 500) server error - ...')
+            error.statusCode = 500
+            return callback(error)
           } else {
             return callback(null, this.output)
           }


### PR DESCRIPTION
### Description

The error message scheme for dockerode/docker-modem errors has changed
 back in 2016: https://github.com/apocas/docker-modem/commit/f47544d20f76e59b3ade708744ed3f920a63119b

```diff
- HTTP code is 500 which indicates error: server error
+ (HTTP code 500) server error - OCI runtime create failed: ...
```

As a result we no longer retry compiles on internal docker errors.

Snip from the currently used version: https://github.com/apocas/docker-modem/blob/v2.1.1/lib/modem.js#L296

> `        '(HTTP code ' + res.statusCode + ') ' +`

#### Potential Impact
Low.

