### PR TITLE
[DockerRunner] retry container inspect on EPIPE

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -26,6 +26,7 @@ const LockManager = require('./DockerLockManager')
 const fs = require('fs')
 const Path = require('path')
 const _ = require('underscore')
+const metrics = require('metrics-sharelatex')
 
 logger.info('using docker runner')
 
@@ -410,6 +411,7 @@ module.exports = DockerRunner = {
 
     const callbackWithRetry = error => {
       if (error.message.match(/EPIPE/)) {
+        metrics.inc('container-inspect-epipe-retry')
         return inspectContainer(container, callback)
       }
       callback(error)
@@ -420,6 +422,7 @@ module.exports = DockerRunner = {
         if ((error != null ? error.statusCode : undefined) === 404) {
           return createAndStartContainer()
         } else if (error != null) {
+          metrics.inc('container-inspect-epipe-error')
           logger.err(
             { container_name: name, error },
             'unable to inspect container to start'

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -357,8 +357,8 @@ describe('DockerRunner', function() {
         return this.DockerRunner.startContainer(
           this.options,
           this.volumes,
-          this.callback,
-          () => {}
+          () => {},
+          this.callback
         )
       })
 


### PR DESCRIPTION
### Description

As part of the investigation for https://github.com/overleaf/issues/issues/2913 we have seen [this error](https://console.cloud.google.com/logs/viewer?project=mgcp-1117973-ol-prod&minLogLevel=0&expandAll=false&timestamp=2020-04-06T13%3A00%3A00.000000000Z&customFacets&limitCustomFacetWidth=true&dateRangeStart=2020-04-06T12%3A00%3A00.000Z&dateRangeEnd=2020-04-06T14%3A00%3A00.000Z&interval=JUMP_TO_TIME&resource=k8s_container%2Fcluster_name%2Fol-gke-02%2Fnamespace_name%2Fdefault&scrollTimestamp=2020-04-06T13%3A15%3A48.826999902Z&advancedFilter=resource.type%3D%22gce_instance%22%0Aresource.labels.instance_id%3D%228160762138875827907%22%0Aresource.labels.zone%3D%22us-east1-b%22%0Aresource.labels.project_id%3D%22mgcp-1117973-ol-prod%22%0Atimestamp%3D%222020-04-06T13%3A15%3A48.826999902Z%22%0AinsertId%3D%22.........4R9wXDbZ_86xeddaTnqzTOE%22), `unable to inspect container to start` caused by a `Error: write EPIPE`.

The `docker inspect` operation sent via the unix socket to the docker daemon failed.

This PR retries a single time if it sees any EPIPE error (read or write).

I paired with @timothee-alby on this.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2913


### Review

There is a separate commit https://github.com/overleaf/clsi/commit/8fa4232148ebc0fa89bbfe7689a0f41c52e32b50 which fixes the order of the `attachStreamHandler` and `callback` sequence for a different test. `attachStreamHandler` is called in addition to the callback, so this was not caught earlier.

#### Potential Impact

High, affects container start. We do have acceptance tests that run though this part of the code base a couple of times as part of the CI pipeline. 

#### Manual Testing Performed

- added unit tests

#### Metrics and Monitoring

- `container-inspect-epipe-retry` inspect failed once
- `container-inspect-epipe-error` inspect failed on retry
