### PR TITLE
set encoding when reading from streams

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -334,7 +334,7 @@ module.exports = CompileManager = {
       proc.on('error', callback)
 
       let stderr = ''
-      proc.stderr.on('data', chunk => (stderr += chunk.toString()))
+      proc.stderr.setEncoding('utf8').on('data', chunk => (stderr += chunk))
 
       return proc.on('close', function(code) {
         if (code === 0) {

--- a/app/js/LocalCommandRunner.js
+++ b/app/js/LocalCommandRunner.js
@@ -46,7 +46,7 @@ module.exports = CommandRunner = {
     const proc = spawn(command[0], command.slice(1), { cwd: directory, env })
 
     let stdout = ''
-    proc.stdout.on('data', data => (stdout += data))
+    proc.stdout.setEncoding('utf8').on('data', data => (stdout += data))
 
     proc.on('error', function(err) {
       logger.err(

--- a/app/js/OutputFileFinder.js
+++ b/app/js/OutputFileFinder.js
@@ -87,7 +87,7 @@ module.exports = OutputFileFinder = {
 
     const proc = spawn('find', args)
     let stdout = ''
-    proc.stdout.on('data', chunk => (stdout += chunk.toString()))
+    proc.stdout.setEncoding('utf8').on('data', chunk => (stdout += chunk))
     proc.on('error', callback)
     return proc.on('close', function(code) {
       if (code !== 0) {

--- a/app/js/OutputFileOptimiser.js
+++ b/app/js/OutputFileOptimiser.js
@@ -78,7 +78,7 @@ module.exports = OutputFileOptimiser = {
     const timer = new Metrics.Timer('qpdf')
     const proc = spawn('qpdf', args)
     let stdout = ''
-    proc.stdout.on('data', chunk => (stdout += chunk.toString()))
+    proc.stdout.setEncoding('utf8').on('data', chunk => (stdout += chunk))
     callback = _.once(callback) // avoid double call back for error and close event
     proc.on('error', function(err) {
       logger.warn({ err, args }, 'qpdf failed')

--- a/test/unit/js/CompileManagerTests.js
+++ b/test/unit/js/CompileManagerTests.js
@@ -294,6 +294,7 @@ describe('CompileManager', function() {
         this.proc = new EventEmitter()
         this.proc.stdout = new EventEmitter()
         this.proc.stderr = new EventEmitter()
+        this.proc.stderr.setEncoding = sinon.stub().returns(this.proc.stderr)
         this.child_process.spawn = sinon.stub().returns(this.proc)
         this.CompileManager.clearProject(
           this.project_id,
@@ -328,6 +329,7 @@ describe('CompileManager', function() {
         this.proc = new EventEmitter()
         this.proc.stdout = new EventEmitter()
         this.proc.stderr = new EventEmitter()
+        this.proc.stderr.setEncoding = sinon.stub().returns(this.proc.stderr)
         this.child_process.spawn = sinon.stub().returns(this.proc)
         this.CompileManager.clearProject(
           this.project_id,

--- a/test/unit/js/OutputFileFinderTests.js
+++ b/test/unit/js/OutputFileFinderTests.js
@@ -70,6 +70,7 @@ describe('OutputFileFinder', function() {
     beforeEach(function() {
       this.proc = new EventEmitter()
       this.proc.stdout = new EventEmitter()
+      this.proc.stdout.setEncoding = sinon.stub().returns(this.proc.stdout)
       this.spawn.returns(this.proc)
       this.directory = '/base/dir'
       return this.OutputFileFinder._getAllFiles(this.directory, this.callback)


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Reading process output in a `data` event using .toString() works most of the time but can lead to utf8 characters being broken across chunk boundaries.  The correct way is to set the encoding on the stream.

https://nodejs.org/api/stream.html#stream_readable_setencoding_encoding

#### Screenshots

NA

#### Related Issues / PRs

Similar case fixed in spelling https://github.com/overleaf/spelling/pull/36

### Review

Small change.

#### Potential Impact

Output file list in production

#### Manual Testing Performed

- [x] Unit and acceptance tests 
- [x] Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Check that compile works and output files are listed on dropdown

#### Metrics and Monitoring

NA

#### Who Needs to Know?
