### PR TITLE
fix deprecated usage of Buffer constructor

### DIFF
--- a/app/js/OutputFileOptimiser.js
+++ b/app/js/OutputFileOptimiser.js
@@ -45,8 +45,7 @@ module.exports = OutputFileOptimiser = {
 
   checkIfPDFIsOptimised(file, callback) {
     const SIZE = 16 * 1024 // check the header of the pdf
-    const result = new Buffer(SIZE)
-    result.fill(0) // prevent leakage of uninitialised buffer
+    const result = Buffer.alloc(SIZE) // fills with zeroes by default
     return fs.open(file, 'r', function(err, fd) {
       if (err != null) {
         return callback(err)

--- a/app/js/SafeReader.js
+++ b/app/js/SafeReader.js
@@ -43,7 +43,7 @@ module.exports = SafeReader = {
           }
           return callback(null, ...Array.from(result))
         })
-      const buff = new Buffer(size, 0) // fill with zeros
+      const buff = Buffer.alloc(size) // fills with zeroes by default
       return fs.read(fd, buff, 0, buff.length, 0, function(
         err,
         bytesRead,

--- a/test/unit/js/OutputFileOptimiserTests.js
+++ b/test/unit/js/OutputFileOptimiserTests.js
@@ -124,7 +124,7 @@ describe('OutputFileOptimiser', function() {
       this.fs.read = sinon
         .stub()
         .withArgs(this.fd)
-        .yields(null, 100, new Buffer('hello /Linearized 1'))
+        .yields(null, 100, Buffer.from('hello /Linearized 1'))
       this.fs.close = sinon
         .stub()
         .withArgs(this.fd)
@@ -140,7 +140,7 @@ describe('OutputFileOptimiser', function() {
         this.fs.read = sinon
           .stub()
           .withArgs(this.fd)
-          .yields(null, 100, new Buffer('hello /Linearized 1'))
+          .yields(null, 100, Buffer.from('hello /Linearized 1'))
         return this.OutputFileOptimiser.checkIfPDFIsOptimised(
           this.src,
           this.callback
@@ -169,7 +169,7 @@ describe('OutputFileOptimiser', function() {
         this.fs.read = sinon
           .stub()
           .withArgs(this.fd)
-          .yields(null, 100, new Buffer('hello not linearized 1'))
+          .yields(null, 100, Buffer.from('hello not linearized 1'))
         return this.OutputFileOptimiser.checkIfPDFIsOptimised(
           this.src,
           this.callback


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This replaces usage of the Buffer constructor `new Buffer` with  `Buffer.alloc` and `Buffer.from`.  The buffer constructor has been deprecated for a long time, as it leaves memory uninitialised.

> `(node:49) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`


https://nodejs.org/api/buffer.html

#### Screenshots

NA

#### Related Issues / PRs



### Review

Small change

#### Potential Impact

Low

#### Manual Testing Performed

- [x] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA