### PR TITLE
[misc] simplify the smoke test and process shutdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -192,7 +192,7 @@ app.get('/oops', function(req, res, next) {
 
 app.get('/status', (req, res, next) => res.send('CLSI is alive\n'))
 
-let PROCESS_IS_TOO_OLD = false
+Settings.processTooOld = false
 if (Settings.processLifespanLimitMs) {
   Settings.processLifespanLimitMs +=
     Settings.processLifespanLimitMs * (Math.random() / 10)
@@ -203,16 +203,16 @@ if (Settings.processLifespanLimitMs) {
 
   setTimeout(() => {
     logger.log('shutting down, process is too old')
-    PROCESS_IS_TOO_OLD = true
+    Settings.processTooOld = true
   }, Settings.processLifespanLimitMs)
 }
 
 if (Settings.smokeTest) {
   function runSmokeTest() {
-    if (PROCESS_IS_TOO_OLD) return
+    if (Settings.processTooOld) return
     logger.log('running smoke tests')
     smokeTest.triggerRun(err => {
-      logger.error({ err }, 'smoke tests failed')
+      if (err) logger.error({ err }, 'smoke tests failed')
       setTimeout(runSmokeTest, 30 * 1000)
     })
   }
@@ -220,7 +220,9 @@ if (Settings.smokeTest) {
 }
 
 app.get('/health_check', function(req, res) {
-  if (PROCESS_IS_TOO_OLD) return res.status(500).json({ processToOld: true })
+  if (Settings.processTooOld) {
+    return res.status(500).json({ processTooOld: true })
+  }
   smokeTest.sendLastResult(res)
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1669,11 +1669,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
-      "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg="
-    },
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
@@ -1877,11 +1872,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
-    },
-    "diff": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
-      "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ="
     },
     "diskusage": {
       "version": "1.1.3",
@@ -3066,11 +3056,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
-    "growl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
-      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto="
-    },
     "gtoken": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
@@ -3575,27 +3560,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
-        }
-      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6062,11 +6026,6 @@
         "object-inspect": "^1.7.0"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -6126,65 +6085,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
-        }
-      }
-    },
-    "smoke-test-sharelatex": {
-      "version": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#bc3e93d18ccee219c0d99e8b02c984ccdd842e1c",
-      "from": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#v0.2.0",
-      "requires": {
-        "mocha": "~1.17.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
-          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
-          "requires": {
-            "graceful-fs": "~2.0.0",
-            "inherits": "2",
-            "minimatch": "~0.2.11"
-          }
-        },
-        "graceful-fs": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
-          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "mocha": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.17.1.tgz",
-          "integrity": "sha1-f3Zx1oUm0HS3uuZgyQmfh+DqHMs=",
-          "requires": {
-            "commander": "2.0.0",
-            "debug": "*",
-            "diff": "1.0.7",
-            "glob": "3.2.3",
-            "growl": "1.7.x",
-            "jade": "0.26.3",
-            "mkdirp": "0.3.5"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.3.5",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-              "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-            }
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "request": "^2.88.2",
     "sequelize": "^5.21.5",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
-    "smoke-test-sharelatex": "git+https://github.com/sharelatex/smoke-test-sharelatex.git#v0.2.0",
     "sqlite3": "^4.1.1",
     "underscore": "^1.9.2",
     "v8-profiler-node8": "^6.1.1",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/2782#issuecomment-625269923


This PR removes the dependency on the out-dated `smoke-test-sharelatex` package and replaces the test running via mocha with simple requests and non-raising assertions.

_Basically a port of https://github.com/das7pad/clsi-sharelatex/commit/fe83b4451da0b4408208b9337e088ef3d24c304e_ 


#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2782#issuecomment-625269923

### Review

I preserved the logic of not caching test results from `/smoke_test_force` runs, but I am happy to change that (and simplify `test/smoke/js/SmokeTests.js` even further).

As part of the `resCacher`  refactoring I changed the process shutdown to a `setTimeout` handler which manipulates a variable in the parent scope -- there is no need to check for the process age on every health check run.

#### Potential Impact


High. CLSI vms could cycle frequently due to failing probes.


#### Manual Testing Performed

- enable smoke tests in the settings defaults (`smokeTest`) and start clsi in the dev-env
- `curl -i 127.0.0.1:3013/health_check` returns `OK` (200)
- `curl -i 127.0.0.1:3013/smoke_test_force` returns `OK` (200)
- restarting the container and immediately running `curl -i 127.0.0.1:3013/health_check` returns `SmokeTestsPending` (500)
- break the compiles: change docker image in settings defaults to a non texlive image (`clsi.docker.image`) and restart clsi
- `curl -i 127.0.0.1:3013/health_check` returns `no pdf returned` (500)
- `curl -i 127.0.0.1:3013/smoke_test_force` returns `no pdf returned` (500)

