### PR TITLE
add refreshExpiryTimeout function

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,10 +359,10 @@ if (!module.parent) {
 
 module.exports = app
 
-setInterval(
-  () => ProjectPersistenceManager.clearExpiredProjects(),
-  (tenMinutes = 10 * 60 * 1000)
-)
+setInterval(() => {
+  ProjectPersistenceManager.refreshExpiryTimeout()
+  ProjectPersistenceManager.clearExpiredProjects()
+}, (tenMinutes = 10 * 60 * 1000))
 
 function __guard__(value, transform) {
   return typeof value !== 'undefined' && value !== null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1883,6 +1883,15 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
       "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ="
     },
+    "diskusage": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.1.3.tgz",
+      "integrity": "sha512-EAyaxl8hy4Ph07kzlzGTfpbZMNAAAHXSZtNEMwdlnSd1noHzvA6HsgKt4fEMSvaEXQYLSphe5rPMxN4WOj0hcQ==",
+      "requires": {
+        "es6-promise": "^4.2.5",
+        "nan": "^2.14.0"
+      }
+    },
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -6924,6 +6933,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
       "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
+    },
+    "when": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "async": "3.2.0",
     "body-parser": "^1.19.0",
+    "diskusage": "^1.1.3",
     "dockerode": "^3.1.0",
     "express": "^4.17.1",
     "fs-extra": "^8.1.0",

--- a/test/unit/js/ProjectPersistenceManagerTests.js
+++ b/test/unit/js/ProjectPersistenceManagerTests.js
@@ -14,6 +14,7 @@
 const SandboxedModule = require('sandboxed-module')
 const sinon = require('sinon')
 require('chai').should()
+const assert = require('chai').assert
 const modulePath = require('path').join(
   __dirname,
   '../../../app/js/ProjectPersistenceManager'
@@ -26,13 +27,72 @@ describe('ProjectPersistenceManager', function() {
       requires: {
         './UrlCache': (this.UrlCache = {}),
         './CompileManager': (this.CompileManager = {}),
-        'logger-sharelatex': (this.logger = { log: sinon.stub() }),
+        diskusage: (this.diskusage = { check: sinon.stub() }),
+        'logger-sharelatex': (this.logger = {
+          log: sinon.stub(),
+          warn: sinon.stub(),
+          err: sinon.stub()
+        }),
+        'settings-sharelatex': (this.settings = {
+          project_cache_length_ms: 1000
+        }),
         './db': (this.db = {})
       }
     })
     this.callback = sinon.stub()
     this.project_id = 'project-id-123'
     return (this.user_id = '1234')
+  })
+
+  describe('refreshExpiryTimeout', function() {
+    it('should leave expiry alone if plenty of disk', function(done) {
+      this.diskusage.check.callsArgWith(1, null, {
+        available: 40,
+        total: 100
+      })
+
+      this.ProjectPersistenceManager.refreshExpiryTimeout(() => {
+        this.ProjectPersistenceManager.EXPIRY_TIMEOUT.should.equal(
+          this.settings.project_cache_length_ms
+        )
+        done()
+      })
+    })
+
+    it('should drop EXPIRY_TIMEOUT 10% if low disk usage', function(done) {
+      this.diskusage.check.callsArgWith(1, null, {
+        available: 5,
+        total: 100
+      })
+
+      this.ProjectPersistenceManager.refreshExpiryTimeout(() => {
+        this.ProjectPersistenceManager.EXPIRY_TIMEOUT.should.equal(900)
+        done()
+      })
+    })
+
+    it('should not drop EXPIRY_TIMEOUT to below 50% of project_cache_length_ms', function(done) {
+      this.diskusage.check.callsArgWith(1, null, {
+        available: 5,
+        total: 100
+      })
+      this.ProjectPersistenceManager.EXPIRY_TIMEOUT = 500
+      this.ProjectPersistenceManager.refreshExpiryTimeout(() => {
+        this.ProjectPersistenceManager.EXPIRY_TIMEOUT.should.equal(500)
+        done()
+      })
+    })
+
+    it('should not modify EXPIRY_TIMEOUT if there is an error getting disk values', function(done) {
+      this.diskusage.check.callsArgWith(1, 'Error', {
+        available: 5,
+        total: 100
+      })
+      this.ProjectPersistenceManager.refreshExpiryTimeout(() => {
+        this.ProjectPersistenceManager.EXPIRY_TIMEOUT.should.equal(1000)
+        done()
+      })
+    })
   })
 
   describe('clearExpiredProjects', function() {


### PR DESCRIPTION
on clsi all data lives inside of / dir
dynamically reduce size of EXPIRY_TIMEOUT if disk starts to get full


<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
adds refreshExpiryTimeout which modifies EXPIRY_TIMEOUT if the disk is filling up

doesn't drop EXPIRY_TIMEOUT to below 50% of the normal threshold to prevent any runaway bugs


#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
