### PR TITLE
record latexmk output

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -217,6 +217,11 @@ module.exports = CompileManager = {
                 error = new Error('compilation')
                 error.validate = 'fail'
               }
+              // make top-level output accesible to user, write in background for simplicity
+              if (output != null) {
+                fs.writeFile(Path.join(compileDir, "output.stdout"), output.stdout, () => { })
+                fs.writeFile(Path.join(compileDir, "output.stderr"), output.stderr, () => { })
+              }
               // compile was killed by user, was a validation, or a compile which failed validation
               if (
                 (error != null ? error.terminated : undefined) ||

--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -217,11 +217,6 @@ module.exports = CompileManager = {
                 error = new Error('compilation')
                 error.validate = 'fail'
               }
-              // make top-level output accesible to user, write in background for simplicity
-              if (output != null) {
-                fs.writeFile(Path.join(compileDir, "output.stdout"), output.stdout, () => { })
-                fs.writeFile(Path.join(compileDir, "output.stderr"), output.stderr, () => { })
-              }
               // compile was killed by user, was a validation, or a compile which failed validation
               if (
                 (error != null ? error.terminated : undefined) ||

--- a/app/js/ResourceWriter.js
+++ b/app/js/ResourceWriter.js
@@ -201,6 +201,10 @@ module.exports = ResourceWriter = {
             // knitr cache
             should_delete = false
           }
+          if (path.match(/^output.(stdout|stderr)$/)) {
+            // latexmk output
+            should_delete = true
+          }
           if (path.match(/^output-.*/)) {
             // Tikz cached figures (default case)
             should_delete = false

--- a/app/js/ResourceWriter.js
+++ b/app/js/ResourceWriter.js
@@ -201,10 +201,6 @@ module.exports = ResourceWriter = {
             // knitr cache
             should_delete = false
           }
-          if (path.match(/^output.(stdout|stderr)$/)) {
-            // latexmk output
-            should_delete = true
-          }
           if (path.match(/^output-.*/)) {
             // Tikz cached figures (default case)
             should_delete = false
@@ -235,7 +231,9 @@ module.exports = ResourceWriter = {
             path === 'output.pdf' ||
             path === 'output.dvi' ||
             path === 'output.log' ||
-            path === 'output.xdv'
+            path === 'output.xdv' ||
+            path === 'output.stdout' ||
+            path === 'output.stderr'
           ) {
             should_delete = true
           }

--- a/test/unit/js/LatexRunnerTests.js
+++ b/test/unit/js/LatexRunnerTests.js
@@ -37,7 +37,10 @@ describe('LatexRunner', function() {
             done() {}
           })
         },
-        './CommandRunner': (this.CommandRunner = {})
+        './CommandRunner': (this.CommandRunner = {}),
+        'fs': (this.fs = {
+          writeFile: sinon.stub().callsArg(2)
+        })
       }
     })
 
@@ -80,6 +83,21 @@ describe('LatexRunner', function() {
             this.image,
             this.timeout,
             this.env
+          )
+          .should.equal(true)
+      })
+
+      it('should record the stdout and stderr', function () {
+        this.fs.writeFile
+          .calledWith(
+            this.directory + '/' + 'output.stdout',
+            "this is stdout"
+          )
+          .should.equal(true)
+        this.fs.writeFile
+          .calledWith(
+            this.directory + '/' + 'output.stderr',
+            "this is stderr"
           )
           .should.equal(true)
       })

--- a/test/unit/js/ResourceWriterTests.js
+++ b/test/unit/js/ResourceWriterTests.js
@@ -230,6 +230,12 @@ describe('ResourceWriter', function() {
         {
           path: '_markdown_main/30893013dec5d869a415610079774c2f.md.tex',
           type: 'tex'
+        },
+        {
+          path: 'output.stdout'
+        },
+        {
+          path: 'output.stderr'
         }
       ]
       this.resources = 'mock-resources'
@@ -256,7 +262,19 @@ describe('ResourceWriter', function() {
         .should.equal(true)
     })
 
-    it('should delete the extra files', function() {
+    it('should delete the stdout log file', function () {
+      return this.ResourceWriter._deleteFileIfNotDirectory
+        .calledWith(path.join(this.basePath, 'output.stdout'))
+        .should.equal(true)
+    })
+
+    it('should delete the stderr log file', function () {
+      return this.ResourceWriter._deleteFileIfNotDirectory
+        .calledWith(path.join(this.basePath, 'output.stderr'))
+        .should.equal(true)
+    })
+
+    it('should delete the extra files', function () {
       return this.ResourceWriter._deleteFileIfNotDirectory
         .calledWith(path.join(this.basePath, 'extra/file.tex'))
         .should.equal(true)


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Currently it is not possible to see the `latexmk` output for a compile, only the tex log file.  This PR writes the latexmk output into two files `output.stdout` and `output.stderr` which can be downloaded from the "Other logs & files" dropdown.  This information should be helpful for debugging support issues.  

#### Screenshots

![image](https://user-images.githubusercontent.com/7457354/82066542-7b544500-96c7-11ea-81d2-74669aad0af2.png)

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3048

### Review

For simplicity I have written the files in the background... maybe a bit lazy?  I can clean it up if needed.

#### Potential Impact

Low

#### Manual Testing Performed

- [X] Test in local dev env
- [X] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@emcsween @henryoswald 