### PR TITLE
[DockerRunner] destroyOldContainers: fix a race confition

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -306,6 +306,10 @@ module.exports = DockerRunner = {
       )
     }
 
+    if (Settings.clsi.docker.runtime) {
+      options.HostConfig.Runtime = Settings.clsi.docker.runtime
+    }
+
     return options
   },
 

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -632,6 +632,9 @@ module.exports = DockerRunner = {
             ttl
           ) {
             if (name.slice(0, 9) === '/project-' && ttl <= 0) {
+              // strip the / prefix
+              // the LockManager uses the plain container name
+              name = name.slice(1)
               return jobs.push(cb =>
                 DockerRunner.destroyContainer(name, id, false, () => cb())
               )

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -67,6 +67,7 @@ if (process.env.DOCKER_RUNNER) {
   module.exports.clsi = {
     dockerRunner: process.env.DOCKER_RUNNER === 'true',
     docker: {
+      runtime: process.env.DOCKER_RUNTIME,
       image:
         process.env.TEXLIVE_IMAGE || 'quay.io/sharelatex/texlive-full:2017.1',
       env: {

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -630,19 +630,19 @@ describe('DockerRunner', function() {
     it('should destroy old containers', function() {
       this.DockerRunner.destroyContainer.callCount.should.equal(1)
       return this.DockerRunner.destroyContainer
-        .calledWith('/project-old-container-name', 'old-container-id')
+        .calledWith('project-old-container-name', 'old-container-id')
         .should.equal(true)
     })
 
     it('should not destroy new containers', function() {
       return this.DockerRunner.destroyContainer
-        .calledWith('/project-new-container-name', 'new-container-id')
+        .calledWith('project-new-container-name', 'new-container-id')
         .should.equal(false)
     })
 
     it('should not destroy non-project containers', function() {
       return this.DockerRunner.destroyContainer
-        .calledWith('/totally-not-a-project-container', 'some-random-id')
+        .calledWith('totally-not-a-project-container', 'some-random-id')
         .should.equal(false)
     })
 


### PR DESCRIPTION
### Description

Import of https://github.com/overleaf/clsi/pull/141 (CI won't run there...)

> The docker api returns each name with a `/` prefix.
>
> In order to not interfere with pending compiles, the deletion process
 has to acquire an internal lock on the container. The LockManager uses
 the plain container name without the slash: `project-xxx` [1].

Due to the missing locking, there is a race between cleanup and active
 compiles.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3093

#### Potential Impact

Low, affects container cleanup only
