### PR TITLE
add setting TEXLIVE_OPENOUT_ANY

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -142,6 +142,10 @@ module.exports = CompileManager = {
         )
       // set up environment variables for chktex
       const env = {}
+      if (Settings.texliveOpenoutAny && Settings.texliveOpenoutAny !== '') {
+        // override default texlive openout_any environment variable
+        env.openout_any = Settings.texliveOpenoutAny
+      }
       // only run chktex on LaTeX files (not knitr .Rtex files or any others)
       const isLaTeXFile =
         request.rootResourcePath != null

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -57,6 +57,7 @@ module.exports = {
   parallelSqlQueryLimit: process.env.FILESTORE_PARALLEL_SQL_QUERY_LIMIT || 1,
   filestoreDomainOveride: process.env.FILESTORE_DOMAIN_OVERRIDE,
   texliveImageNameOveride: process.env.TEX_LIVE_IMAGE_NAME_OVERRIDE,
+  texliveOpenoutAny: process.env.TEXLIVE_OPENOUT_ANY,
   sentry: {
     dsn: process.env.SENTRY_DSN
   }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Allow setting `openout_any` when running compiles.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3048

### Review

I've added this as a setting to avoid the work of updating all the texlive images.  It's also easier to revert if we encounter problems.  If it works out ok we can move it into the images and delete this code.

#### Potential Impact

Low.

#### Manual Testing Performed

- [x]  Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Add the environment variable `TEXLIVE_OPENOUT_ANY=a` in the clsi deployment (https://github.com/overleaf/google-ops/pull/1072).

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA