### PR TITLE
error on missing profile

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -87,10 +87,11 @@ if (process.env.DOCKER_RUNNER) {
       JSON.parse(require('fs').readFileSync(seccompProfilePath))
     )
   } catch (error) {
-    console.log(
+    console.error(
       error,
-      `could not load seccom profile from ${seccompProfilePath}`
+      `could not load seccomp profile from ${seccompProfilePath}`
     )
+    process.exit(1)
   }
 
   module.exports.path.synctexBaseDir = () => '/compile'


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Exit on startup if the seccomp profile cannot be loaded.

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

The code path to load the seccomp profile is only followed for DockerRunner instances. We always attempt to load it in that case.

#### Potential Impact

Low.

#### Manual Testing Performed

- [X] Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @mserranom if this affects server pro