### PR TITLE
add missing setting for optimiseInDocker

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -76,6 +76,7 @@ if (process.env.DOCKER_RUNNER) {
       socketPath: '/var/run/docker.sock',
       user: process.env.TEXLIVE_IMAGE_USER || 'tex'
     },
+    optimiseInDocker: true,
     expireProjectAfterIdleMs: 24 * 60 * 60 * 1000,
     checkProjectsIntervalMs: 10 * 60 * 1000
   }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR adds a missing setting for `clsi.optimiseInDocker` at [OutputCacheManager.js#L355-L364](https://github.com/overleaf/clsi/blob/cffbd4e9efbdab23534f9c3e96ea7a808417fa5d/app/js/OutputCacheManager.js#L355-L364), which skips any attempt to optimise the final pdf when qpdf is running in the docker container.  There is no qpdf outside the container so that always fails. 

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

Small change.

#### Potential Impact

Optimisation of pdf only.

#### Manual Testing Performed

- [X] Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ] Check that this gets rid of the `spawn qpdf ENOENT` errors in the logs.

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @mserranom 