### PR TITLE
migrate from underscore to lodash

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -25,7 +25,7 @@ const async = require('async')
 const LockManager = require('./DockerLockManager')
 const fs = require('fs')
 const Path = require('path')
-const _ = require('underscore')
+const _ = require('lodash')
 const metrics = require('metrics-sharelatex')
 
 logger.info('using docker runner')

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -27,7 +27,6 @@ const fs = require('fs')
 const Path = require('path')
 const _ = require('lodash')
 
-
 logger.info('using docker runner')
 
 const usingSiblingContainers = () =>

--- a/app/js/OutputCacheManager.js
+++ b/app/js/OutputCacheManager.js
@@ -19,7 +19,7 @@ const fs = require('fs')
 const fse = require('fs-extra')
 const Path = require('path')
 const logger = require('logger-sharelatex')
-const _ = require('underscore')
+const _ = require('lodash')
 const Settings = require('settings-sharelatex')
 const crypto = require('crypto')
 

--- a/app/js/OutputFileOptimiser.js
+++ b/app/js/OutputFileOptimiser.js
@@ -19,7 +19,7 @@ const Path = require('path')
 const { spawn } = require('child_process')
 const logger = require('logger-sharelatex')
 const Metrics = require('./Metrics')
-const _ = require('underscore')
+const _ = require('lodash')
 
 module.exports = OutputFileOptimiser = {
   optimiseFile(src, dst, callback) {

--- a/app/js/db.js
+++ b/app/js/db.js
@@ -10,7 +10,7 @@
  */
 const Sequelize = require('sequelize')
 const Settings = require('settings-sharelatex')
-const _ = require('underscore')
+const _ = require('lodash')
 const logger = require('logger-sharelatex')
 
 const options = _.extend({ logging: false }, Settings.mysql.clsi)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6640,11 +6640,6 @@
       "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
-    "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6833,11 +6828,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
       "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ=="
-    },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fs-extra": "^8.1.0",
     "heapdump": "^0.3.15",
     "lockfile": "^1.0.4",
+    "lodash": "^4.17.15",
     "logger-sharelatex": "^1.9.1",
     "lynx": "0.2.0",
     "metrics-sharelatex": "^2.6.0",
@@ -35,7 +36,6 @@
     "sequelize": "^5.21.5",
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
     "sqlite3": "^4.1.1",
-    "underscore": "^1.9.2",
     "v8-profiler-node8": "^6.1.1",
     "wrench": "~1.5.9"
   },

--- a/test/load/js/loadTest.js
+++ b/test/load/js/loadTest.js
@@ -13,7 +13,7 @@ const request = require('request')
 const Settings = require('settings-sharelatex')
 const async = require('async')
 const fs = require('fs')
-const _ = require('underscore')
+const _ = require('lodash')
 const concurentCompiles = 5
 const totalCompiles = 50
 

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -70,7 +70,8 @@ describe('DockerRunner', function() {
             return runner(callback)
           }
         }
-      }
+      },
+      globals: { Math } // used by lodash
     })
     this.Docker = Docker
     this.getContainer = Docker.prototype.getContainer

--- a/test/unit/js/OutputFileOptimiserTests.js
+++ b/test/unit/js/OutputFileOptimiserTests.js
@@ -30,7 +30,8 @@ describe('OutputFileOptimiser', function() {
         child_process: { spawn: (this.spawn = sinon.stub()) },
         'logger-sharelatex': { log: sinon.stub(), warn: sinon.stub() },
         './Metrics': {}
-      }
+      },
+      globals: { Math } // used by lodash
     })
     this.directory = '/test/dir'
     return (this.callback = sinon.stub())


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Migrate from `underscore` to `lodash`.  I needed to use a `lodash` function in another PR so it was time to migrate.


#### Screenshots

NA


#### Related Issues / PRs

NA

### Review

We only use a few `underscore` functions, and they are available in `lodash` without any change to the signature.

I had to update the sandbox module calls in the unit tests to include `Math` as a `global` because `lodash` makes use of it and causes the tests to fail if it is unavailable.

#### Potential Impact

Low

#### Manual Testing Performed

- [x] Unit and acceptance tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

