### PR TITLE
add compile groups support

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -199,7 +199,8 @@ module.exports = CompileManager = {
               timeout: request.timeout,
               image: request.imageName,
               flags: request.flags,
-              environment: env
+              environment: env,
+              compileGroup: request.compileGroup
             },
             function(error, output, stats, timings) {
               // request was for validation only
@@ -536,6 +537,7 @@ module.exports = CompileManager = {
     const directory = getCompileDir(project_id, user_id)
     const timeout = 60 * 1000 // increased to allow for large projects
     const compileName = getCompileName(project_id, user_id)
+    const compileGroup = 'synctex'
     return CommandRunner.run(
       compileName,
       command,
@@ -543,6 +545,7 @@ module.exports = CompileManager = {
       Settings.clsi != null ? Settings.clsi.docker.image : undefined,
       timeout,
       {},
+      compileGroup,
       function(error, output) {
         if (error != null) {
           logger.err(
@@ -606,6 +609,7 @@ module.exports = CompileManager = {
     const compileDir = getCompileDir(project_id, user_id)
     const timeout = 60 * 1000
     const compileName = getCompileName(project_id, user_id)
+    const compileGroup = 'wordcount'
     return fse.ensureDir(compileDir, function(error) {
       if (error != null) {
         logger.err(
@@ -621,6 +625,7 @@ module.exports = CompileManager = {
         image,
         timeout,
         {},
+        compileGroup,
         function(error) {
           if (error != null) {
             return callback(error)

--- a/app/js/LatexRunner.js
+++ b/app/js/LatexRunner.js
@@ -36,7 +36,8 @@ module.exports = LatexRunner = {
       timeout,
       image,
       environment,
-      flags
+      flags,
+      compileGroup
     } = options
     if (!compiler) {
       compiler = 'pdflatex'
@@ -46,7 +47,15 @@ module.exports = LatexRunner = {
     } // milliseconds
 
     logger.log(
-      { directory, compiler, timeout, mainFile, environment, flags },
+      {
+        directory,
+        compiler,
+        timeout,
+        mainFile,
+        environment,
+        flags,
+        compileGroup
+      },
       'starting compile'
     )
 
@@ -79,6 +88,7 @@ module.exports = LatexRunner = {
       image,
       timeout,
       environment,
+      compileGroup,
       function(error, output) {
         delete ProcessTable[id]
         if (error != null) {

--- a/app/js/LocalCommandRunner.js
+++ b/app/js/LocalCommandRunner.js
@@ -20,7 +20,16 @@ const logger = require('logger-sharelatex')
 logger.info('using standard command runner')
 
 module.exports = CommandRunner = {
-  run(project_id, command, directory, image, timeout, environment, callback) {
+  run(
+    project_id,
+    command,
+    directory,
+    image,
+    timeout,
+    environment,
+    compileGroup,
+    callback
+  ) {
     let key, value
     if (callback == null) {
       callback = function(error) {}

--- a/app/js/RequestParser.js
+++ b/app/js/RequestParser.js
@@ -74,7 +74,17 @@ module.exports = RequestParser = {
         default: [],
         type: 'object'
       })
-
+      if (settings.allowedCompileGroups) {
+        response.compileGroup = this._parseAttribute(
+          'compileGroup',
+          compile.options.compileGroup,
+          {
+            validValues: settings.allowedCompileGroups,
+            default: '',
+            type: 'string'
+          }
+        )
+      }
       // The syncType specifies whether the request contains all
       // resources (full) or only those resources to be updated
       // in-place (incremental).

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -63,6 +63,17 @@ module.exports = {
   }
 }
 
+if (process.env.ALLOWED_COMPILE_GROUPS) {
+  try {
+    module.exports.allowedCompileGroups = process.env.ALLOWED_COMPILE_GROUPS.split(
+      ' '
+    )
+  } catch (error) {
+    console.error(error, 'could not apply allowed compile group setting')
+    process.exit(1)
+  }
+}
+
 if (process.env.DOCKER_RUNNER) {
   let seccompProfilePath
   module.exports.clsi = {
@@ -80,6 +91,21 @@ if (process.env.DOCKER_RUNNER) {
     optimiseInDocker: true,
     expireProjectAfterIdleMs: 24 * 60 * 60 * 1000,
     checkProjectsIntervalMs: 10 * 60 * 1000
+  }
+
+  try {
+    // Override individual docker settings using path-based keys, e.g.:
+    // compileGroupDockerConfigs = {
+    //    priority: { 'HostConfig.CpuShares': 100 }
+    //    beta: { 'dotted.path.here', 'value'}
+    // }
+    const compileGroupConfig = JSON.parse(
+      process.env.COMPILE_GROUP_DOCKER_CONFIGS || '{}'
+    )
+    module.exports.clsi.docker.compileGroupConfig = compileGroupConfig
+  } catch (error) {
+    console.error(error, 'could not apply compile group docker configs')
+    process.exit(1)
   }
 
   try {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -102,7 +102,15 @@ if (process.env.DOCKER_RUNNER) {
     const compileGroupConfig = JSON.parse(
       process.env.COMPILE_GROUP_DOCKER_CONFIGS || '{}'
     )
-    module.exports.clsi.docker.compileGroupConfig = compileGroupConfig
+    // Automatically clean up wordcount and synctex containers
+    const defaultCompileGroupConfig = {
+      wordcount: { 'HostConfig.AutoRemove': true },
+      synctex: { 'HostConfig.AutoRemove': true }
+    }
+    module.exports.clsi.docker.compileGroupConfig = Object.assign(
+      defaultCompileGroupConfig,
+      compileGroupConfig
+    )
   } catch (error) {
     console.error(error, 'could not apply compile group docker configs')
     process.exit(1)

--- a/test/unit/js/CompileManagerTests.js
+++ b/test/unit/js/CompileManagerTests.js
@@ -160,7 +160,8 @@ describe('CompileManager', function() {
         compiler: (this.compiler = 'pdflatex'),
         timeout: (this.timeout = 42000),
         imageName: (this.image = 'example.com/image'),
-        flags: (this.flags = ['-file-line-error'])
+        flags: (this.flags = ['-file-line-error']),
+        compileGroup: (this.compileGroup = 'compile-group')
       }
       this.env = {}
       this.Settings.compileDir = 'compiles'
@@ -199,7 +200,8 @@ describe('CompileManager', function() {
             timeout: this.timeout,
             image: this.image,
             flags: this.flags,
-            environment: this.env
+            environment: this.env,
+            compileGroup: this.compileGroup
           })
           .should.equal(true)
       })
@@ -253,7 +255,8 @@ describe('CompileManager', function() {
               CHKTEX_OPTIONS: '-nall -e9 -e10 -w15 -w16',
               CHKTEX_EXIT_ON_ERROR: 1,
               CHKTEX_ULIMIT_OPTIONS: '-t 5 -v 64000'
-            }
+            },
+            compileGroup: this.compileGroup
           })
           .should.equal(true)
       })
@@ -275,7 +278,8 @@ describe('CompileManager', function() {
             timeout: this.timeout,
             image: this.image,
             flags: this.flags,
-            environment: this.env
+            environment: this.env,
+            compileGroup: this.compileGroup
           })
           .should.equal(true)
       })
@@ -384,7 +388,7 @@ describe('CompileManager', function() {
         this.stdout = `NODE\t${this.page}\t${this.h}\t${this.v}\t${this.width}\t${this.height}\n`
         this.CommandRunner.run = sinon
           .stub()
-          .callsArgWith(6, null, { stdout: this.stdout })
+          .callsArgWith(7, null, { stdout: this.stdout })
         return this.CompileManager.syncFromCode(
           this.project_id,
           this.user_id,
@@ -443,7 +447,7 @@ describe('CompileManager', function() {
         this.stdout = `NODE\t${this.Settings.path.compilesDir}/${this.project_id}-${this.user_id}/${this.file_name}\t${this.line}\t${this.column}\n`
         this.CommandRunner.run = sinon
           .stub()
-          .callsArgWith(6, null, { stdout: this.stdout })
+          .callsArgWith(7, null, { stdout: this.stdout })
         return this.CompileManager.syncFromPdf(
           this.project_id,
           this.user_id,
@@ -485,7 +489,7 @@ describe('CompileManager', function() {
 
   return describe('wordcount', function() {
     beforeEach(function() {
-      this.CommandRunner.run = sinon.stub().callsArg(6)
+      this.CommandRunner.run = sinon.stub().callsArg(7)
       this.fs.readFile = sinon
         .stub()
         .callsArgWith(

--- a/test/unit/js/LatexRunnerTests.js
+++ b/test/unit/js/LatexRunnerTests.js
@@ -48,6 +48,7 @@ describe('LatexRunner', function() {
     this.mainFile = 'main-file.tex'
     this.compiler = 'pdflatex'
     this.image = 'example.com/image'
+    this.compileGroup = 'compile-group'
     this.callback = sinon.stub()
     this.project_id = 'project-id-123'
     return (this.env = { foo: '123' })
@@ -55,7 +56,7 @@ describe('LatexRunner', function() {
 
   return describe('runLatex', function() {
     beforeEach(function() {
-      return (this.CommandRunner.run = sinon.stub().callsArgWith(6, null, {
+      return (this.CommandRunner.run = sinon.stub().callsArgWith(7, null, {
         stdout: 'this is stdout',
         stderr: 'this is stderr'
       }))
@@ -71,7 +72,8 @@ describe('LatexRunner', function() {
             compiler: this.compiler,
             timeout: (this.timeout = 42000),
             image: this.image,
-            environment: this.env
+            environment: this.env,
+            compileGroup: this.compileGroup
           },
           this.callback
         )
@@ -85,7 +87,8 @@ describe('LatexRunner', function() {
             this.directory,
             this.image,
             this.timeout,
-            this.env
+            this.env,
+            this.compileGroup
           )
           .should.equal(true)
       })


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR adds support for overriding individual docker container settings based on an extra "compile group" parameter.  For example, a "priority" compileGroup could override the HostConfig.CpuShares configuration to give containers in that group more cpu than other groups.  Any other setting for the docker container can also be overridden.  The optional `compileGroup` parameter is sent in the clsi request from web. 

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2458

### Review

To allow individual settings to be overridden, the configuration uses dotted path based keys with lodash's `_.set(obj,path,val)` method (otherwise entire subobjects would be overwritten, rather than individual properties).  This requires a migration from underscore to lodash, which is in #178. 

Web already has a concept of compile groups, and can send requests to a different set of clsi servers based on the owner of the project.  This is useful for choosing different hardware (node pools) but we may also want to chose different docker settings for the compile groups, so I have extended the scope of the compile group to make the clsi aware of it too.

As an example, the synctex and wordcount containers now have their own compile groups ("synctex" and "wordcount") and there is  a default setting of `HostConfig.Autoremove:true` for these compile groups, since the containers are only ever used once and don't need to persist (unlike the container used for the compilation).  

#### Potential Impact

Low if we are not adding any new settings.

#### Manual Testing Performed

- [X] Unit and acceptance tests

#### Accessibility

NA

### Deployment

Requires environment variables to be set for `ALLOWED_COMPILE_GROUPS` and `COMPILE_GROUP_DOCKER_CONFIGS` if the compile groups are being used.

#### Deployment Checklist

- [ ]  Check that `synctex` and `texcount` containers are being cleaned up automatically.

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA 