### PR TITLE
handle EPIPE errors in CompileController

### DIFF
--- a/app/js/CompileController.js
+++ b/app/js/CompileController.js
@@ -55,6 +55,10 @@ module.exports = CompileController = {
             } else if (error instanceof Errors.FilesOutOfSyncError) {
               code = 409 // Http 409 Conflict
               status = 'retry'
+            } else if (error && error.code === 'EPIPE') {
+              // docker returns EPIPE when shutting down
+              code = 503 // send 503 Unavailable response
+              status = 'unavailable'
             } else if (error != null ? error.terminated : undefined) {
               status = 'terminated'
             } else if (error != null ? error.validate : undefined) {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Adds missing handling of EPIPE errors in the CompileController

After watch a few deploys I realised that the check for the EPIPE errors in the error handling middleware was missing a lot of errors - it turns out the CompileController does its own handling of the response code, so we need to check there too.

#### Screenshots

![Screenshot from 2020-06-18 10-07-08](https://user-images.githubusercontent.com/7457354/85001386-82012c80-b14b-11ea-8bc9-402c17d54048.png)



#### Related Issues / PRs

Previous attempt https://github.com/overleaf/clsi/pull/175

### Review

Small change

#### Potential Impact

Should only affect instances that are shutting down.

#### Manual Testing Performed

- [X] Unit and acceptance tests.

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Look at 500's chart for the clsi.

#### Who Needs to Know?

@henryoswald 