### PR TITLE
Fixed NPE when Settings.clsi is defined but Settings.clsi.docker is not

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -520,7 +520,9 @@ module.exports = CompileManager = {
         compileName,
         command,
         directory,
-        Settings.clsi != null ? Settings.clsi.docker.image : undefined,
+        Settings.clsi && Settings.clsi.docker
+          ? Settings.clsi.docker.image
+          : undefined,
         timeout,
         {},
         compileGroup,


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

`Settings.clsi` has been `undefined` on Overleaf CE until `Settings.clsi.optimiseInDocker` was introduced in https://github.com/overleaf/overleaf/pull/740.

This was causing a null pointer exception in `CompileManager` when invoking `synctex`:

```
/var/www/sharelatex/clsi/app/js/CompileManager.js:539
      Settings.clsi != null ? Settings.clsi.docker.image : undefined,
                                                   ^

TypeError: Cannot read property 'image' of undefined
    at Object._runSynctex (/var/www/sharelatex/clsi/app/js/CompileManager.js:539:52)
    at /var/www/sharelatex/clsi/app/js/CompileManager.js:437:29
    at xfs.stat (/var/www/sharelatex/clsi/node_modules/fs-extra/lib/mkdirs/mkdirs.js:56:16)
    at callback (/var/www/sharelatex/clsi/node_modules/graceful-fs/polyfills.js:295:20)
    at FSReqWrap.oncomplete (fs.js:154:5)
```



#### Related Issues / PRs

Fixes https://github.com/overleaf/overleaf/issues/756


### Review



#### Potential Impact

Shouldn't have any


#### Manual Testing Performed

- [x] Check `syntex` works as expected in Overleaf CE