### PR TITLE
[ExampleDocumentTests] drop out in case of an error during compilation

### DIFF
--- a/test/acceptance/js/ExampleDocumentTests.js
+++ b/test/acceptance/js/ExampleDocumentTests.js
@@ -235,7 +235,7 @@ describe('Example Documents', function() {
                 ) === 'failure'
               ) {
                 console.log('DEBUG: error', error, 'body', JSON.stringify(body))
-                return done(new Error("Compile failed"))
+                return done(new Error('Compile failed'))
               }
               const pdf = Client.getOutputFile(body, 'pdf')
               return downloadAndComparePdf(
@@ -264,7 +264,7 @@ describe('Example Documents', function() {
                 ) === 'failure'
               ) {
                 console.log('DEBUG: error', error, 'body', JSON.stringify(body))
-                return done(new Error("Compile failed"))
+                return done(new Error('Compile failed'))
               }
               const pdf = Client.getOutputFile(body, 'pdf')
               return downloadAndComparePdf(


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

See https://github.com/overleaf/clsi/pull/123 for details.

#### Related Issues / PRs

https://github.com/overleaf/clsi/pull/123

#### Potential Impact

Low. Affects error path in acceptance tests only.

#### Manual Testing Performed

- I merged the patch into my fork back in April 2019 and it's causing clean test bail-outs since then.
