### PR TITLE
[LocalCommandRunner] run: block a double call of the callback

### DIFF
--- a/app/js/LocalCommandRunner.js
+++ b/app/js/LocalCommandRunner.js
@@ -15,6 +15,7 @@
  */
 let CommandRunner
 const { spawn } = require('child_process')
+const _ = require('underscore')
 const logger = require('logger-sharelatex')
 
 logger.info('using standard command runner')
@@ -33,6 +34,8 @@ module.exports = CommandRunner = {
     let key, value
     if (callback == null) {
       callback = function(error) {}
+    } else {
+      callback = _.once(callback)
     }
     command = Array.from(command).map(arg =>
       arg.toString().replace('$COMPILE_DIR', directory)


### PR DESCRIPTION
### Description

See #132 for details. Needs an import to run CI.

Given that we are not going to force all customers onto sibling compiles it's probably worth importing this PR as well.

#### Related Issues / PRs

#132

#### Potential Impact

Low. Affects unhappy path in local compiles only.
