### PR TITLE
Mount /home/tex in an anonymous volume

### DIFF
--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -611,8 +611,8 @@ const DockerRunner = {
       containerMonitorTimeout = undefined
     }
     if (containerMonitorInterval) {
-      clearInterval(containerMonitorTimeout)
-      containerMonitorTimeout = undefined
+      clearInterval(containerMonitorInterval)
+      containerMonitorInterval = undefined
     }
   }
 }

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -277,6 +277,7 @@ const DockerRunner = {
     if (Settings.clsi.docker.Readonly) {
       options.HostConfig.ReadonlyRootfs = true
       options.HostConfig.Tmpfs = { '/tmp': 'rw,noexec,nosuid,size=65536k' }
+      options.Volumes['/home/tex'] = {}
     }
 
     // Allow per-compile group overriding of individual settings
@@ -519,7 +520,7 @@ const DockerRunner = {
   _destroyContainer(containerId, shouldForce, callback) {
     logger.log({ containerId }, 'destroying docker container')
     const container = dockerode.getContainer(containerId)
-    container.remove({ force: shouldForce === true }, (error) => {
+    container.remove({ force: shouldForce === true, v: true }, (error) => {
       if (error != null && error.statusCode === 404) {
         logger.warn(
           { err: error, containerId },

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -8,7 +8,6 @@
 // Fix any style issues and re-enable lint.
 /*
  * decaffeinate suggestions:
- * DS101: Remove unnecessary use of Array.from
  * DS102: Remove unnecessary code created because of implicit returns
  * DS103: Rewrite code to no longer use __guard__
  * DS205: Consider reworking code to avoid use of IIFEs
@@ -77,7 +76,7 @@ module.exports = DockerRunner = {
     const volumes = {}
     volumes[directory] = '/compile'
 
-    command = Array.from(command).map((arg) =>
+    command = command.map((arg) =>
       __guardMethod__(arg.toString(), 'replace', (o) =>
         o.replace('$COMPILE_DIR', '/compile')
       )
@@ -177,7 +176,7 @@ module.exports = DockerRunner = {
       _callback = function (error, output) {}
     }
     const callback = function (...args) {
-      _callback(...Array.from(args || []))
+      _callback(...args)
       // Only call the callback once
       return (_callback = function () {})
     }
@@ -538,7 +537,7 @@ module.exports = DockerRunner = {
       _callback = function (error, exitCode) {}
     }
     const callback = function (...args) {
-      _callback(...Array.from(args || []))
+      _callback(...args)
       // Only call the callback once
       return (_callback = function () {})
     }
@@ -668,7 +667,7 @@ module.exports = DockerRunner = {
         return callback(error)
       }
       const jobs = []
-      for (const container of Array.from(containers || [])) {
+      for (const container of containers) {
         ;((container) =>
           DockerRunner.examineOldContainer(container, function (
             err,

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -1,8 +1,4 @@
-/* eslint-disable
-    no-return-assign,
-    no-unused-vars,
-*/
-let DockerRunner, oneHour
+let DockerRunner
 const Settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
 const Docker = require('dockerode')
@@ -14,6 +10,7 @@ const fs = require('fs')
 const Path = require('path')
 const _ = require('lodash')
 
+const ONE_HOUR_IN_MS = 60 * 60 * 1000
 logger.info('using docker runner')
 
 const usingSiblingContainers = () =>
@@ -559,8 +556,7 @@ module.exports = DockerRunner = {
 
   // handle expiry of docker containers
 
-  MAX_CONTAINER_AGE:
-    Settings.clsi.docker.maxContainerAge || (oneHour = 60 * 60 * 1000),
+  MAX_CONTAINER_AGE: Settings.clsi.docker.maxContainerAge || ONE_HOUR_IN_MS,
 
   examineOldContainer(container, callback) {
     const name = container.Name || (container.Names && container.Names[0])
@@ -618,7 +614,7 @@ module.exports = DockerRunner = {
               logger.error({ err }, 'failed to destroy old containers')
             }
           }),
-        (oneHour = 60 * 60 * 1000)
+        ONE_HOUR_IN_MS
       )
     }, randomDelay)
   },

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -137,12 +137,7 @@ const DockerRunner = {
   },
 
   _runAndWaitForContainer(options, volumes, timeout, _callback) {
-    const callback = function (...args) {
-      _callback(...args)
-      // Only call the callback once
-      _callback = function () {}
-    }
-
+    const callback = _.once(_callback)
     const { name } = options
 
     let streamEnded = false
@@ -463,11 +458,7 @@ const DockerRunner = {
   },
 
   waitForContainer(containerId, timeout, _callback) {
-    const callback = function (...args) {
-      _callback(...args)
-      // Only call the callback once
-      _callback = function () {}
-    }
+    const callback = _.once(_callback)
 
     const container = dockerode.getContainer(containerId)
 

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -22,11 +22,6 @@ let containerMonitorTimeout
 let containerMonitorInterval
 
 module.exports = DockerRunner = {
-  ERR_NOT_DIRECTORY: new Error('not a directory'),
-  ERR_TERMINATED: new Error('terminated'),
-  ERR_EXITED: new Error('exited'),
-  ERR_TIMED_OUT: new Error('container timed out'),
-
   run(
     projectId,
     command,
@@ -190,13 +185,13 @@ module.exports = DockerRunner = {
           }
           if (exitCode === 137) {
             // exit status from kill -9
-            err = DockerRunner.ERR_TERMINATED
+            err = new Error('terminated')
             err.terminated = true
             return callback(err)
           }
           if (exitCode === 1) {
             // exit status from chktex
-            err = DockerRunner.ERR_EXITED
+            err = new Error('exited')
             err.code = exitCode
             return callback(err)
           }
@@ -353,7 +348,7 @@ module.exports = DockerRunner = {
           return cb(err)
         }
         if (!stats.isDirectory()) {
-          return cb(DockerRunner.ERR_NOT_DIRECTORY)
+          return cb(new Error('not a directory'))
         }
         cb()
       })
@@ -501,7 +496,7 @@ module.exports = DockerRunner = {
       }
       if (timedOut) {
         logger.log({ containerId }, 'docker container timed out')
-        error = DockerRunner.ERR_TIMED_OUT
+        error = new Error('container timed out')
         error.timedout = true
         callback(error)
       } else {

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -50,9 +50,6 @@ module.exports = DockerRunner = {
     callback
   ) {
     let name
-    if (callback == null) {
-      callback = function (error, output) {}
-    }
     if (usingSiblingContainers()) {
       const _newPath = Settings.path.sandboxedCompilesHostDir
       logger.log(
@@ -135,9 +132,6 @@ module.exports = DockerRunner = {
   },
 
   kill(container_id, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
     logger.log({ container_id }, 'sending kill signal to container')
     const container = dockerode.getContainer(container_id)
     container.kill(function (error) {
@@ -162,9 +156,6 @@ module.exports = DockerRunner = {
   },
 
   _runAndWaitForContainer(options, volumes, timeout, _callback) {
-    if (_callback == null) {
-      _callback = function (error, output) {}
-    }
     const callback = function (...args) {
       _callback(...args)
       // Only call the callback once
@@ -366,9 +357,6 @@ module.exports = DockerRunner = {
 
   // Check that volumes exist and are directories
   _checkVolumes(options, volumes, callback) {
-    if (callback == null) {
-      callback = function (error, containerName) {}
-    }
     if (usingSiblingContainers()) {
       // Server Pro, with sibling-containers active, skip checks
       return callback(null)
@@ -392,9 +380,6 @@ module.exports = DockerRunner = {
   },
 
   _startContainer(options, volumes, attachStreamHandler, callback) {
-    if (callback == null) {
-      callback = function (error, output) {}
-    }
     callback = _.once(callback)
     const { name } = options
 
@@ -510,9 +495,6 @@ module.exports = DockerRunner = {
   },
 
   waitForContainer(containerId, timeout, _callback) {
-    if (_callback == null) {
-      _callback = function (error, exitCode) {}
-    }
     const callback = function (...args) {
       _callback(...args)
       // Only call the callback once
@@ -564,9 +546,6 @@ module.exports = DockerRunner = {
     // async exception, but if you delete by id it just does a normal
     // error callback. We fall back to deleting by name if no id is
     // supplied.
-    if (callback == null) {
-      callback = function (error) {}
-    }
     LockManager.runWithLock(
       containerName,
       (releaseLock) =>
@@ -580,9 +559,6 @@ module.exports = DockerRunner = {
   },
 
   _destroyContainer(containerId, shouldForce, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
     logger.log({ container_id: containerId }, 'destroying docker container')
     const container = dockerode.getContainer(containerId)
     container.remove({ force: shouldForce === true }, function (error) {
@@ -614,9 +590,6 @@ module.exports = DockerRunner = {
     Settings.clsi.docker.maxContainerAge || (oneHour = 60 * 60 * 1000),
 
   examineOldContainer(container, callback) {
-    if (callback == null) {
-      callback = function (error, name, id, ttl) {}
-    }
     const name =
       container.Name ||
       (container.Names != null ? container.Names[0] : undefined)
@@ -633,9 +606,6 @@ module.exports = DockerRunner = {
   },
 
   destroyOldContainers(callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
     dockerode.listContainers({ all: true }, function (error, containers) {
       if (error != null) {
         return callback(error)
@@ -677,7 +647,12 @@ module.exports = DockerRunner = {
     const randomDelay = Math.floor(Math.random() * 5 * 60 * 1000)
     containerMonitorTimeout = setTimeout(() => {
       containerMonitorInterval = setInterval(
-        () => DockerRunner.destroyOldContainers(),
+        () =>
+          DockerRunner.destroyOldContainers((err) => {
+            if (err) {
+              logger.error({ err }, 'failed to destroy old containers')
+            }
+          }),
         (oneHour = 60 * 60 * 1000)
       )
     }, randomDelay)

--- a/app/js/DockerRunner.js
+++ b/app/js/DockerRunner.js
@@ -4,13 +4,6 @@
     no-return-assign,
     no-unused-vars,
 */
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 let DockerRunner, oneHour
 const Settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
@@ -286,10 +279,7 @@ module.exports = DockerRunner = {
       }
     }
 
-    if (
-      (Settings.path != null ? Settings.path.synctexBinHostPath : undefined) !=
-      null
-    ) {
+    if (Settings.path != null && Settings.path.synctexBinHostPath != null) {
       options.HostConfig.Binds.push(
         `${Settings.path.synctexBinHostPath}:/opt/synctex:ro`
       )
@@ -367,7 +357,7 @@ module.exports = DockerRunner = {
         if (err != null) {
           return cb(err)
         }
-        if (!(stats != null ? stats.isDirectory() : undefined)) {
+        if (!stats.isDirectory()) {
           return cb(DockerRunner.ERR_NOT_DIRECTORY)
         }
         cb()
@@ -402,20 +392,17 @@ module.exports = DockerRunner = {
             return callback(error)
           }
           container.start(function (error) {
-            if (
-              error != null &&
-              (error != null ? error.statusCode : undefined) !== 304
-            ) {
-              // already running
+            if (error != null && error.statusCode !== 304) {
               callback(error)
             } else {
+              // already running
               callback()
             }
           })
         }
       )
     container.inspect(function (error, stats) {
-      if ((error != null ? error.statusCode : undefined) === 404) {
+      if (error != null && error.statusCode === 404) {
         createAndStartContainer()
       } else if (error != null) {
         logger.err(
@@ -562,10 +549,7 @@ module.exports = DockerRunner = {
     logger.log({ container_id: containerId }, 'destroying docker container')
     const container = dockerode.getContainer(containerId)
     container.remove({ force: shouldForce === true }, function (error) {
-      if (
-        error != null &&
-        (error != null ? error.statusCode : undefined) === 404
-      ) {
+      if (error != null && error.statusCode === 404) {
         logger.warn(
           { err: error, container_id: containerId },
           'container not found, continuing'
@@ -590,9 +574,7 @@ module.exports = DockerRunner = {
     Settings.clsi.docker.maxContainerAge || (oneHour = 60 * 60 * 1000),
 
   examineOldContainer(container, callback) {
-    const name =
-      container.Name ||
-      (container.Names != null ? container.Names[0] : undefined)
+    const name = container.Name || (container.Names && container.Names[0])
     const created = container.Created * 1000 // creation time is returned in seconds
     const now = Date.now()
     const age = now - created

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -802,7 +802,7 @@ describe('DockerRunner', function () {
         (err) => {
           this.fakeContainer.remove.callCount.should.equal(1)
           this.fakeContainer.remove
-            .calledWith({ force: true })
+            .calledWithMatch({ force: true })
             .should.equal(true)
           return done()
         }
@@ -816,7 +816,7 @@ describe('DockerRunner', function () {
         (err) => {
           this.fakeContainer.remove.callCount.should.equal(1)
           this.fakeContainer.remove
-            .calledWith({ force: false })
+            .calledWithMatch({ force: false })
             .should.equal(true)
           return done()
         }

--- a/test/unit/js/DockerRunnerTests.js
+++ b/test/unit/js/DockerRunnerTests.js
@@ -802,7 +802,7 @@ describe('DockerRunner', function () {
         (err) => {
           this.fakeContainer.remove.callCount.should.equal(1)
           this.fakeContainer.remove
-            .calledWithMatch({ force: true })
+            .calledWith({ force: true, v: true })
             .should.equal(true)
           return done()
         }
@@ -816,7 +816,7 @@ describe('DockerRunner', function () {
         (err) => {
           this.fakeContainer.remove.callCount.should.equal(1)
           this.fakeContainer.remove
-            .calledWithMatch({ force: false })
+            .calledWith({ force: false, v: true })
             .should.equal(true)
           return done()
         }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

When we mount the container's root filesystem as read-only, mount an anonymous volume in /home/tex so that it's writable. Our TeX Live images have cached content in /home/tex. This content will automatically get copied by Docker into this 
anonymous volume.

#### Related Issues / PRs

* overleaf/texlive-images#28

### Review

I initially thought I'd need to change more code, so I did a decaf cleanup. As usual, it's in separate commits and best reviewed commit by commit.

#### Potential Impact

The changes only impact read-only mode, which is not turned on in production at the moment.

#### Manual Testing Performed

- [x] Compile a LuaLaTeX document and verify that it can use the LuaTeX font names database in /home/tex