### PR TITLE
[misc] install settings-sharelatex from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6106,8 +6106,9 @@
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "settings-sharelatex": {
-      "version": "git+https://github.com/sharelatex/settings-sharelatex.git#93f63d029b52fef8825c3a401b2b6a7ba29b4750",
-      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/settings-sharelatex/-/settings-sharelatex-1.1.0.tgz",
+      "integrity": "sha512-f7D+0lnlohoteSn6IKTH72NE+JnAdMWTKwQglAuimZWTID2FRRItZSGeYMTRpvEnaQApkoVwRp//WRMsiddnqw==",
       "requires": {
         "coffee-script": "1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mysql": "^2.18.1",
     "request": "^2.88.2",
     "sequelize": "^5.21.5",
-    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.1.0",
+    "settings-sharelatex": "^1.1.0",
     "sqlite3": "^4.1.1",
     "v8-profiler-node8": "^6.1.1",
     "wrench": "~1.5.9"


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3731

Installing npm packages via git is flaky (https://github.com/overleaf/third-party-references/pull/42).
This PR is switching the installation of the setttings module to the existing npm package -- which all the other service are using too.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3731

#### Potential Impact

Low. The tests are not working without this package being properly installed, so the chance of it breaking in prod are low.
