### PR TITLE
decaff cleanup ResourceStateManager

### DIFF
--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -6,7 +6,6 @@
 // Fix any style issues and re-enable lint.
 /*
  * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
  * DS201: Simplify complex destructure assignments
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
@@ -45,7 +44,7 @@ module.exports = ResourceStateManager = {
     if (state == null) {
       // remove the file if no state passed in
       logger.log({ state, basePath }, 'clearing sync state')
-      return fs.unlink(stateFile, function (err) {
+      fs.unlink(stateFile, function (err) {
         if (err != null && err.code !== 'ENOENT') {
           return callback(err)
         } else {
@@ -55,7 +54,7 @@ module.exports = ResourceStateManager = {
     } else {
       logger.log({ state, basePath }, 'writing sync state')
       const resourceList = resources.map((resource) => resource.path)
-      return fs.writeFile(
+      fs.writeFile(
         stateFile,
         [...resourceList, `stateHash:${state}`].join('\n'),
         callback
@@ -69,7 +68,7 @@ module.exports = ResourceStateManager = {
     }
     const stateFile = Path.join(basePath, this.SYNC_STATE_FILE)
     const size = this.SYNC_STATE_MAX_SIZE
-    return SafeReader.readFile(stateFile, size, 'utf8', function (
+    SafeReader.readFile(stateFile, size, 'utf8', function (
       err,
       result,
       bytesRead
@@ -98,7 +97,7 @@ module.exports = ResourceStateManager = {
         )
       } else {
         const resources = resourceList.map((path) => ({ path }))
-        return callback(null, resources)
+        callback(null, resources)
       }
     })
   },
@@ -136,7 +135,7 @@ module.exports = ResourceStateManager = {
         )
       )
     } else {
-      return callback()
+      callback()
     }
   },
 }

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -6,7 +6,6 @@
 // Fix any style issues and re-enable lint.
 /*
  * decaffeinate suggestions:
- * DS101: Remove unnecessary use of Array.from
  * DS102: Remove unnecessary code created because of implicit returns
  * DS103: Rewrite code to no longer use __guard__
  * DS201: Simplify complex destructure assignments
@@ -56,12 +55,10 @@ module.exports = ResourceStateManager = {
       })
     } else {
       logger.log({ state, basePath }, 'writing sync state')
-      const resourceList = Array.from(resources).map(
-        (resource) => resource.path
-      )
+      const resourceList = resources.map((resource) => resource.path)
       return fs.writeFile(
         stateFile,
-        [...Array.from(resourceList), `stateHash:${state}`].join('\n'),
+        [...resourceList, `stateHash:${state}`].join('\n'),
         callback
       )
     }
@@ -104,7 +101,7 @@ module.exports = ResourceStateManager = {
           new Errors.FilesOutOfSyncError('invalid state for incremental update')
         )
       } else {
-        const resources = Array.from(resourceList).map((path) => ({ path }))
+        const resources = resourceList.map((path) => ({ path }))
         return callback(null, resources)
       }
     })
@@ -116,7 +113,7 @@ module.exports = ResourceStateManager = {
     if (callback == null) {
       callback = function (error) {}
     }
-    for (file of Array.from(resources || [])) {
+    for (file of resources || []) {
       for (const dir of Array.from(
         __guard__(file != null ? file.path : undefined, (x) => x.split('/'))
       )) {
@@ -127,10 +124,10 @@ module.exports = ResourceStateManager = {
     }
     // check if any of the input files are not present in list of files
     const seenFile = {}
-    for (file of Array.from(allFiles)) {
+    for (file of allFiles) {
       seenFile[file] = true
     }
-    const missingFiles = Array.from(resources)
+    const missingFiles = resources
       .filter((resource) => !seenFile[resource.path])
       .map((resource) => resource.path)
     if ((missingFiles != null ? missingFiles.length : undefined) > 0) {
@@ -146,7 +143,7 @@ module.exports = ResourceStateManager = {
     } else {
       return callback()
     }
-  }
+  },
 }
 
 function __guard__(value, transform) {

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -106,14 +106,11 @@ module.exports = ResourceStateManager = {
       return callback(new Error('relative path in resource file list'))
     }
     // check if any of the input files are not present in list of files
-    const seenFile = {}
-    for (file of allFiles) {
-      seenFile[file] = true
-    }
+    const seenFiles = new Set(allFiles)
     const missingFiles = resources
-      .filter((resource) => !seenFile[resource.path])
       .map((resource) => resource.path)
-    if (missingFiles && missingFiles.length > 0) {
+      .filter((path) => !seenFiles.has(path))
+    if (missingFiles.length > 0) {
       logger.err(
         { missingFiles, basePath, allFiles, resources },
         'missing input files for project'

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -13,7 +13,6 @@ let ResourceStateManager
 const Path = require('path')
 const fs = require('fs')
 const logger = require('logger-sharelatex')
-const settings = require('settings-sharelatex')
 const Errors = require('./Errors')
 const SafeReader = require('./SafeReader')
 

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -98,13 +98,12 @@ module.exports = ResourceStateManager = {
   checkResourceFiles(resources, allFiles, basePath, callback) {
     // check the paths are all relative to current directory
     let file
-    for (file of resources || []) {
-      if (file && file.path) {
-        const dirs = file.path.split('/')
-        if (dirs.indexOf('..') !== -1) {
-          return callback(new Error('relative path in resource file list'))
-        }
-      }
+    const containsRelativePath = (resource) => {
+      const dirs = resource.path.split('/')
+      return dirs.indexOf('..') !== -1
+    }
+    if (resources.some(containsRelativePath)) {
+      return callback(new Error('relative path in resource file list'))
     }
     // check if any of the input files are not present in list of files
     const seenFile = {}

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -96,7 +96,6 @@ module.exports = ResourceStateManager = {
 
   checkResourceFiles(resources, allFiles, basePath, callback) {
     // check the paths are all relative to current directory
-    let file
     const containsRelativePath = (resource) => {
       const dirs = resource.path.split('/')
       return dirs.indexOf('..') !== -1

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -7,7 +7,6 @@
 /*
  * decaffeinate suggestions:
  * DS102: Remove unnecessary code created because of implicit returns
- * DS103: Rewrite code to no longer use __guard__
  * DS201: Simplify complex destructure assignments
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
@@ -84,10 +83,7 @@ module.exports = ResourceStateManager = {
           'project state file truncated'
         )
       }
-      const array =
-        __guard__(result != null ? result.toString() : undefined, (x) =>
-          x.split('\n')
-        ) || []
+      const array = result.toString().split('\n')
       const adjustedLength = Math.max(array.length, 1)
       const resourceList = array.slice(0, adjustedLength - 1)
       const oldState = array[adjustedLength - 1]
@@ -114,10 +110,9 @@ module.exports = ResourceStateManager = {
       callback = function (error) {}
     }
     for (file of resources || []) {
-      for (const dir of Array.from(
-        __guard__(file != null ? file.path : undefined, (x) => x.split('/'))
-      )) {
-        if (dir === '..') {
+      if (file && file.path) {
+        const dirs = file.path.split('/')
+        if (dirs.indexOf('..') !== -1) {
           return callback(new Error('relative path in resource file list'))
         }
       }
@@ -144,10 +139,4 @@ module.exports = ResourceStateManager = {
       return callback()
     }
   },
-}
-
-function __guard__(value, transform) {
-  return typeof value !== 'undefined' && value !== null
-    ? transform(value)
-    : undefined
 }

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -109,5 +109,5 @@ module.exports = {
     } else {
       callback()
     }
-  },
+  }
 }

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -1,11 +1,10 @@
-let ResourceStateManager
 const Path = require('path')
 const fs = require('fs')
 const logger = require('logger-sharelatex')
 const Errors = require('./Errors')
 const SafeReader = require('./SafeReader')
 
-module.exports = ResourceStateManager = {
+module.exports = {
   // The sync state is an identifier which must match for an
   // incremental update to be allowed.
   //

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -7,7 +7,6 @@
 /*
  * decaffeinate suggestions:
  * DS201: Simplify complex destructure assignments
- * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 let ResourceStateManager
@@ -37,15 +36,12 @@ module.exports = ResourceStateManager = {
   SYNC_STATE_MAX_SIZE: 128 * 1024,
 
   saveProjectState(state, resources, basePath, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
     const stateFile = Path.join(basePath, this.SYNC_STATE_FILE)
     if (state == null) {
       // remove the file if no state passed in
       logger.log({ state, basePath }, 'clearing sync state')
       fs.unlink(stateFile, function (err) {
-        if (err != null && err.code !== 'ENOENT') {
+        if (err && err.code !== 'ENOENT') {
           return callback(err)
         } else {
           return callback()
@@ -63,9 +59,6 @@ module.exports = ResourceStateManager = {
   },
 
   checkProjectStateMatches(state, basePath, callback) {
-    if (callback == null) {
-      callback = function (error, resources) {}
-    }
     const stateFile = Path.join(basePath, this.SYNC_STATE_FILE)
     const size = this.SYNC_STATE_MAX_SIZE
     SafeReader.readFile(stateFile, size, 'utf8', function (
@@ -73,7 +66,7 @@ module.exports = ResourceStateManager = {
       result,
       bytesRead
     ) {
-      if (err != null) {
+      if (err) {
         return callback(err)
       }
       if (bytesRead === size) {
@@ -105,9 +98,6 @@ module.exports = ResourceStateManager = {
   checkResourceFiles(resources, allFiles, basePath, callback) {
     // check the paths are all relative to current directory
     let file
-    if (callback == null) {
-      callback = function (error) {}
-    }
     for (file of resources || []) {
       if (file && file.path) {
         const dirs = file.path.split('/')
@@ -124,7 +114,7 @@ module.exports = ResourceStateManager = {
     const missingFiles = resources
       .filter((resource) => !seenFile[resource.path])
       .map((resource) => resource.path)
-    if ((missingFiles != null ? missingFiles.length : undefined) > 0) {
+    if (missingFiles && missingFiles.length > 0) {
       logger.err(
         { missingFiles, basePath, allFiles, resources },
         'missing input files for project'

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -1,14 +1,3 @@
-/* eslint-disable
-    handle-callback-err,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS201: Simplify complex destructure assignments
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 let ResourceStateManager
 const Path = require('path')
 const fs = require('fs')


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Decaff cleanup of ResourceStateManager.

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

I also changed an occurrence of {} to a Set for safety.

#### Potential Impact

ResourceStateManager controls the check for incremental vs full compiles.  

#### Manual Testing Performed

- [X] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ] Check that projects can be compiled
- [ ] Check metrics for full vs incremental compiles

#### Metrics and Monitoring

Metrics are here: https://github.com/overleaf/web-internal/blob/0ee54ec4721e96fce84d0f5c950353ce5c166010/app%2Fsrc%2FFeatures%2FCompile%2FClsiManager.js#L514-L524

We need to add the metrics for full vs incremental compiles to a dashboard to see them in stackdriver.  Can look at them in prometheus for a quick check.

#### Who Needs to Know?
