### PR TITLE
[misc] CompileController: exact match for output.pdf

### DIFF
--- a/app/js/CompileController.js
+++ b/app/js/CompileController.js
@@ -80,11 +80,7 @@ module.exports = CompileController = {
               let file
               status = 'failure'
               for (file of Array.from(outputFiles)) {
-                if (
-                  file.path != null
-                    ? file.path.match(/output\.pdf$/)
-                    : undefined
-                ) {
+                if (file.path === 'output.pdf') {
                   status = 'success'
                 }
               }

--- a/test/unit/js/CompileControllerTests.js
+++ b/test/unit/js/CompileControllerTests.js
@@ -129,6 +129,47 @@ describe('CompileController', function () {
       })
     })
 
+    describe('with user provided fake_output.pdf', function () {
+      beforeEach(function () {
+        this.output_files = [
+          {
+            path: 'fake_output.pdf',
+            type: 'pdf',
+            build: 1234
+          },
+          {
+            path: 'output.log',
+            type: 'log',
+            build: 1234
+          }
+        ]
+        this.CompileManager.doCompileWithLock = sinon
+          .stub()
+          .callsArgWith(1, null, this.output_files)
+        this.CompileController.compile(this.req, this.res)
+      })
+
+      it('should return the JSON response with status failure', function () {
+        this.res.status.calledWith(200).should.equal(true)
+        this.res.send
+          .calledWith({
+            compile: {
+              status: 'failure',
+              error: null,
+              outputFiles: this.output_files.map((file) => {
+                return {
+                  url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
+                  path: file.path,
+                  type: file.type,
+                  build: file.build
+                }
+              })
+            }
+          })
+          .should.equal(true)
+      })
+    })
+
     describe('with an error', function () {
       beforeEach(function () {
         this.CompileManager.doCompileWithLock = sinon


### PR DESCRIPTION


<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For cleanup under the umbrella of https://github.com/overleaf/issues/issues/3777

The previous regex could mistake user provided pdf files, like
 `fake_output.pdf`, as the final output file.
The frontend expects to find a `output.pdf` file on success.

https://github.com/overleaf/web-internal/blob/5553ede59d75306a7085424b5e0a20dabe0792f5/frontend/js/ide/pdf/controllers/PdfController.js#L372-L395

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3777

#### Review

This code base is due for a big decaff-cleanup, hence I restrained from simplying the loop and made a minimal change.

#### Potential Impact

Low.

#### Manual Testing Performed

- added test case
