### PR TITLE
add unit test for non-existent state file

### DIFF
--- a/test/unit/js/ResourceStateManagerTests.js
+++ b/test/unit/js/ResourceStateManagerTests.js
@@ -122,6 +122,32 @@ describe('ResourceStateManager', function () {
       })
     })
 
+    describe('when the state file is not present', function () {
+      beforeEach(function () {
+        this.SafeReader.readFile = sinon.stub().callsArg(3)
+        return this.ResourceStateManager.checkProjectStateMatches(
+          this.state,
+          this.basePath,
+          this.callback
+        )
+      })
+
+      it('should read the resource file', function () {
+        return this.SafeReader.readFile
+          .calledWith(this.resourceFileName)
+          .should.equal(true)
+      })
+
+      it('should call the callback with an error', function () {
+        this.callback
+          .calledWith(sinon.match(Errors.FilesOutOfSyncError))
+          .should.equal(true)
+
+        const message = this.callback.args[0][0].message
+        expect(message).to.include('invalid state for incremental update')
+      })
+    })
+
     return describe('when the state does not match', function () {
       beforeEach(function () {
         this.SafeReader.readFile = sinon


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This adds a unit test for the case of a missing state file (in addition to the tests for matched and unmatched state files)

In #200 I removed a guard function that I thought wasn't needed -- it turned out that it was needed, but there was no unit test for that case.

#### Screenshots

N/A


#### Related Issues / PRs

#200 and #208

### Review

Adds unit test only

There will be another PR to add in the broken code in #200 and add a fix which will make the test pass.

#### Potential Impact

NA

#### Manual Testing Performed

- [X]  unit tests
- [X] check that test fails with #200 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA 

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @henryoswald 