### PR TITLE
add uncaughtException handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,6 +339,15 @@ const loadHttpPort = Settings.internal.load_balancer_agent.local_port
 
 if (!module.parent) {
   // Called directly
+
+  // handle uncaught exceptions when running in production
+  if (Settings.catchErrors) {
+    process.removeAllListeners('uncaughtException')
+    process.on('uncaughtException', (error) =>
+      logger.error({ err: error }, 'uncaughtException')
+    )
+  }
+
   app.listen(port, host, (error) => {
     if (error) {
       logger.fatal({ error }, `Error starting CLSI on ${host}:${port}`)

--- a/app.js
+++ b/app.js
@@ -213,6 +213,12 @@ app.get('/oops', function (req, res, next) {
   return res.send('error\n')
 })
 
+app.get('/oops-internal', function (req, res, next) {
+  setTimeout(function () {
+    throw new Error('Test error')
+  }, 1)
+})
+
 app.get('/status', (req, res, next) => res.send('CLSI is alive\n'))
 
 Settings.processTooOld = false

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -25,6 +25,8 @@ module.exports = {
   processLifespanLimitMs:
     parseInt(process.env.PROCESS_LIFE_SPAN_LIMIT_MS) || 60 * 60 * 24 * 1000 * 2,
 
+  catchErrors: process.env.CATCH_ERRORS === 'true',
+
   path: {
     compilesDir: Path.resolve(__dirname, '../compiles'),
     outputDir: Path.resolve(__dirname, '../output'),


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Add an uncaughtException handler to the clsi,  enabled when the environment variable `CATCH_ERRORS` is set to "true".

#### Screenshots

NA

#### Related Issues / PRs

#204

### Review

The code is copied from web [app.js#L33-L38](https://github.com/overleaf/web-internal/blob/460ac7cdcb36ac18631bb021d04f3ce9924737ec/app.js#L33-L38).

#### Potential Impact

Low.  May cause exceptions to go unnoticed.

#### Manual Testing Performed

- [X]  Test in dev env: `curl localhost:3013/oops-internal` should not crash the server when `CATCH_ERRORS="true"`.

Expected output:
```
clsi_1                    | {"name":"clsi","hostname":"1bdc9193edae","pid":46,"level":50,"err":{"message":"Test error","name":"Error","stack":"Error: Test error\n    at Timeout._onTimeout (/app/app.js:218:11)\n    at ontimeout (timers.js:436:11)\n    at tryOnTimeout (timers.js:300:5)\n    at listOnTimeout (timers.js:263:5)\n    at Timer.processTimers (timers.js:223:10)","info":{}},"msg":"uncaughtException","time":"2021-01-26T15:26:27.342Z","v":0}
```

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]

#### Metrics and Monitoring

We may want to add a log-based alert for the errors.

#### Who Needs to Know?

cc @emcsween 