### PR TITLE
fix for exception in "decaff cleanup ResourceStateManager"

### DIFF
--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -1,27 +1,10 @@
-/* eslint-disable
-    handle-callback-err,
-    no-unused-vars,
-*/
-// TODO: This file was created by bulk-decaffeinate.
-// Fix any style issues and re-enable lint.
-/*
- * decaffeinate suggestions:
- * DS101: Remove unnecessary use of Array.from
- * DS102: Remove unnecessary code created because of implicit returns
- * DS103: Rewrite code to no longer use __guard__
- * DS201: Simplify complex destructure assignments
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-let ResourceStateManager
 const Path = require('path')
 const fs = require('fs')
 const logger = require('logger-sharelatex')
-const settings = require('settings-sharelatex')
 const Errors = require('./Errors')
 const SafeReader = require('./SafeReader')
 
-module.exports = ResourceStateManager = {
+module.exports = {
   // The sync state is an identifier which must match for an
   // incremental update to be allowed.
   //
@@ -40,15 +23,12 @@ module.exports = ResourceStateManager = {
   SYNC_STATE_MAX_SIZE: 128 * 1024,
 
   saveProjectState(state, resources, basePath, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
     const stateFile = Path.join(basePath, this.SYNC_STATE_FILE)
     if (state == null) {
       // remove the file if no state passed in
       logger.log({ state, basePath }, 'clearing sync state')
-      return fs.unlink(stateFile, function (err) {
-        if (err != null && err.code !== 'ENOENT') {
+      fs.unlink(stateFile, function (err) {
+        if (err && err.code !== 'ENOENT') {
           return callback(err)
         } else {
           return callback()
@@ -56,29 +36,24 @@ module.exports = ResourceStateManager = {
       })
     } else {
       logger.log({ state, basePath }, 'writing sync state')
-      const resourceList = Array.from(resources).map(
-        (resource) => resource.path
-      )
-      return fs.writeFile(
+      const resourceList = resources.map((resource) => resource.path)
+      fs.writeFile(
         stateFile,
-        [...Array.from(resourceList), `stateHash:${state}`].join('\n'),
+        [...resourceList, `stateHash:${state}`].join('\n'),
         callback
       )
     }
   },
 
   checkProjectStateMatches(state, basePath, callback) {
-    if (callback == null) {
-      callback = function (error, resources) {}
-    }
     const stateFile = Path.join(basePath, this.SYNC_STATE_FILE)
     const size = this.SYNC_STATE_MAX_SIZE
-    return SafeReader.readFile(stateFile, size, 'utf8', function (
+    SafeReader.readFile(stateFile, size, 'utf8', function (
       err,
       result,
       bytesRead
     ) {
-      if (err != null) {
+      if (err) {
         return callback(err)
       }
       if (bytesRead === size) {
@@ -87,10 +62,7 @@ module.exports = ResourceStateManager = {
           'project state file truncated'
         )
       }
-      const array =
-        __guard__(result != null ? result.toString() : undefined, (x) =>
-          x.split('\n')
-        ) || []
+      const array = result.toString().split('\n')
       const adjustedLength = Math.max(array.length, 1)
       const resourceList = array.slice(0, adjustedLength - 1)
       const oldState = array[adjustedLength - 1]
@@ -104,36 +76,27 @@ module.exports = ResourceStateManager = {
           new Errors.FilesOutOfSyncError('invalid state for incremental update')
         )
       } else {
-        const resources = Array.from(resourceList).map((path) => ({ path }))
-        return callback(null, resources)
+        const resources = resourceList.map((path) => ({ path }))
+        callback(null, resources)
       }
     })
   },
 
   checkResourceFiles(resources, allFiles, basePath, callback) {
     // check the paths are all relative to current directory
-    let file
-    if (callback == null) {
-      callback = function (error) {}
+    const containsRelativePath = (resource) => {
+      const dirs = resource.path.split('/')
+      return dirs.indexOf('..') !== -1
     }
-    for (file of Array.from(resources || [])) {
-      for (const dir of Array.from(
-        __guard__(file != null ? file.path : undefined, (x) => x.split('/'))
-      )) {
-        if (dir === '..') {
-          return callback(new Error('relative path in resource file list'))
-        }
-      }
+    if (resources.some(containsRelativePath)) {
+      return callback(new Error('relative path in resource file list'))
     }
     // check if any of the input files are not present in list of files
-    const seenFile = {}
-    for (file of Array.from(allFiles)) {
-      seenFile[file] = true
-    }
-    const missingFiles = Array.from(resources)
-      .filter((resource) => !seenFile[resource.path])
+    const seenFiles = new Set(allFiles)
+    const missingFiles = resources
       .map((resource) => resource.path)
-    if ((missingFiles != null ? missingFiles.length : undefined) > 0) {
+      .filter((path) => !seenFiles.has(path))
+    if (missingFiles.length > 0) {
       logger.err(
         { missingFiles, basePath, allFiles, resources },
         'missing input files for project'
@@ -144,13 +107,7 @@ module.exports = ResourceStateManager = {
         )
       )
     } else {
-      return callback()
+      callback()
     }
   }
-}
-
-function __guard__(value, transform) {
-  return typeof value !== 'undefined' && value !== null
-    ? transform(value)
-    : undefined
 }

--- a/app/js/ResourceStateManager.js
+++ b/app/js/ResourceStateManager.js
@@ -62,7 +62,7 @@ module.exports = {
           'project state file truncated'
         )
       }
-      const array = result.toString().split('\n')
+      const array = result ? result.toString().split('\n') : []
       const adjustedLength = Math.max(array.length, 1)
       const resourceList = array.slice(0, adjustedLength - 1)
       const oldState = array[adjustedLength - 1]


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This adds a fix for the exception in the decaff cleanup of ResourceStateManager.

The fix is in the commit https://github.com/overleaf/clsi/commit/f84ba5ad4cbdee1658911a7b82f45b21181141f9

![image](https://user-images.githubusercontent.com/7457354/105983632-eea0ba00-6090-11eb-99b9-c5f71f4221e7.png)

The other two commits bring back the original decaff cleanup commit (by reverting the revert commit) and bring in the additional unit test for the exception in #206.

#### Screenshots

NA

#### Related Issues / PRs

#200 and #206

overleaf/issues#3207

### Review

I added a test on `result` and fall back to an empty array `[]` when undefined (the original behaviour).

#### Potential Impact

Code path is hit when user clears cache.

#### Manual Testing Performed

- [X]  Unit test
- [X]  Test in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Compile project, remove the `.project-sync-state` file from the compile directory, recompile - then check that clsi has not crashed.

#### Metrics and Monitoring

Check logs for any uncaught exception errors from #207 

#### Who Needs to Know?

NA
