### PR TITLE
Try groupmod before groupadd for dockeronhost

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,12 @@
 
 docker --version >&2
 
-# add the node user to the docker group on the host
+# set the dockeronhost group id in the container to the group id from the host
 DOCKER_GROUP=$(stat -c '%g' /var/run/docker.sock)
-groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost
-usermod -aG dockeronhost node
+# try to modify an existing group id
+groupmod --non-unique --gid ${DOCKER_GROUP} dockeronhost
+# if the group doesn't exist yet, create it
+if [ $? -eq 4 ]; then groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost; fi
 
 # compatibility: initial volume setup
 chown node:node /app/cache


### PR DESCRIPTION
To avoid logging a "group already exists" error when the `clsi` service restarts in the dev environment, this first attempts to set the id of an existing `dockeronhost` user then falls back to creating a new `dockeronhost` group if it doesn't already exist.

If this is risky, or it might not work in the production environment, feel free to close this.