### PR TITLE
Ensure that app folders exist before running chown in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,7 @@ usermod -aG dockeronhost node
 mkdir -p /app/cache && chown node:node /app/cache
 mkdir -p /app/compiles && chown node:node /app/compiles
 mkdir -p /app/db && chown node:node /app/db
+mkdir -p /app/output && chown node:node /app/output
 
 # make synctex available for remount in compiles
 cp /app/bin/synctex /app/bin/synctex-mount/synctex

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,9 +8,9 @@ groupadd --non-unique --gid ${DOCKER_GROUP} dockeronhost
 usermod -aG dockeronhost node
 
 # compatibility: initial volume setup
-chown node:node /app/cache
-chown node:node /app/compiles
-chown node:node /app/db
+mkdir -p /app/cache && chown node:node /app/cache
+mkdir -p /app/compiles && chown node:node /app/compiles
+mkdir -p /app/db && chown node:node /app/db
 
 # make synctex available for remount in compiles
 cp /app/bin/synctex /app/bin/synctex-mount/synctex


### PR DESCRIPTION
This runs `mkdir -p` to ensure that each folder is created before running `chown node:node`, in `entrypoint.sh`, to avoid an error that's otherwise thrown when the `app/cache` folder doesn't exist on the host: 

```
/bin/chown: cannot access '/app/cache': No such file or directory
```

There's something similar in `Dockerfile` but it only runs in the `app` stage:

```Dockerfile
RUN mkdir -p cache compiles db output \
  &&  chown node:node cache compiles db output
```
