### PR TITLE
Add flag to qpdf, to preserve PDF/A compliance

### DIFF
--- a/app/js/OutputFileOptimiser.js
+++ b/app/js/OutputFileOptimiser.js
@@ -71,7 +71,7 @@ module.exports = OutputFileOptimiser = {
       callback = function (error) {}
     }
     const tmpOutput = dst + '.opt'
-    const args = ['--linearize', src, tmpOutput]
+    const args = ['--linearize', '--newline-before-endstream', src, tmpOutput]
     logger.log({ args }, 'running qpdf command')
 
     const timer = new Metrics.Timer('qpdf')


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This fixes an issue where CE/SP users (not using sandboxed compiles), and using the optimization pass built into CLSI (rather than in a texlive docker image), would end up with optimized PDFs that failed PDF/A validation.

This PR adds the `--newline-before-endstream` flag when invoking `qpdf`, preserving PDF/A compliance.

#### Triggering the Problem

This code path is used when all of these conditions are met:

- running in CE, or in Server Pro
- without sandboxed compiles
- `OPTIMISE_PDF` is set to `false`

**NOTE!!!**: `OPTIMISE_PDF` is misleadingly named, as it corresponds to `Settings.clsi.optimiseInDocker` in the settings file. By default this is set to `true` in CE/SP, meaning that the application should _rely on the texlive docker process to optimise the PDF_. Setting this to `false` does not mean "Don't optimise the PDF", it means _"Don't optimise the PDF in the texlive docker process, optimise it in the CLSI process instead"_.

To be very clear:

- `OPTIMISE_PDF = true` : rely on the docker texlive image to optimise the PDF
- `OPTIMISE_PDF = false` : optimise the PDF in the CLSI process, by calling `qpdf`


#### Upshot

When running without sandboxed compiles, PDFs pass PDF/A validation, regardless of the value of `OPTIMISE_PDF`.


#### Related Issues / PRs

- Fixes https://github.com/overleaf/issues/issues/3029


#### Manual Testing Performed

- [x] In CE, test compiles with and without `OPTIMISE_PDF`
- [x] Check the resulting PDFs with this validation tool: http://www.pdf-online.com/osa/validate.aspx


#### Accessibility

- Good for accessibility... of PDFs


#### Who Needs to Know?
