### PR TITLE
[misc] bump the version of the metrics module to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,202 @@
         }
       }
     },
+    "@google-cloud/debug-agent": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/debug-agent/-/debug-agent-5.1.3.tgz",
+      "integrity": "sha512-WbzeEz4MvPlM7DX2QBsPcWgF62u7LSQv/oMYPl0L+TddTebqjDKiVXwxpzWk61NIfcKiet3dyCbPIt3N5o8XPQ==",
+      "requires": {
+        "@google-cloud/common": "^3.0.0",
+        "acorn": "^8.0.0",
+        "coffeescript": "^2.0.0",
+        "console-log-level": "^1.4.0",
+        "extend": "^3.0.2",
+        "findit2": "^2.2.3",
+        "gcp-metadata": "^4.0.0",
+        "p-limit": "^3.0.1",
+        "semver": "^7.0.0",
+        "source-map": "^0.6.1",
+        "split": "^1.0.0"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
+          "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
+          "requires": {
+            "@google-cloud/projectify": "^2.0.0",
+            "@google-cloud/promisify": "^2.0.0",
+            "arrify": "^2.0.1",
+            "duplexify": "^4.1.1",
+            "ent": "^2.2.0",
+            "extend": "^3.0.2",
+            "google-auth-library": "^6.1.1",
+            "retry-request": "^4.1.1",
+            "teeny-request": "^7.0.0"
+          }
+        },
+        "@google-cloud/projectify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
+          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ=="
+        },
+        "@google-cloud/promisify": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
+          "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
+        },
+        "acorn": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
+        },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "coffeescript": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
+          "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
+        },
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "gaxios": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+          "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+          "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+          "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+          "requires": {
+            "node-forge": "^0.10.0"
+          }
+        },
+        "gtoken": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "google-p12-pem": "^3.0.3",
+            "jws": "^4.0.0"
+          }
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "teeny-request": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+          "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+          "requires": {
+            "http-proxy-agent": "^4.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "node-fetch": "^2.6.1",
+            "stream-events": "^1.0.5",
+            "uuid": "^8.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@google-cloud/logging": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/logging/-/logging-7.3.0.tgz",
@@ -301,6 +497,216 @@
         "extend": "^3.0.2"
       }
     },
+    "@google-cloud/profiler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/profiler/-/profiler-4.1.0.tgz",
+      "integrity": "sha512-9e1zXRctLSUHAoAsFGwE4rS28fr0siiG+jXl5OpwTK8ZAUlxb70aosHaZGdsv8YXrYKjuiufjRZ/OXCs0XLI9g==",
+      "requires": {
+        "@google-cloud/common": "^3.0.0",
+        "@types/console-log-level": "^1.4.0",
+        "@types/semver": "^7.0.0",
+        "console-log-level": "^1.4.0",
+        "delay": "^4.0.1",
+        "extend": "^3.0.2",
+        "gcp-metadata": "^4.0.0",
+        "parse-duration": "^0.4.4",
+        "pprof": "3.0.0",
+        "pretty-ms": "^7.0.0",
+        "protobufjs": "~6.10.0",
+        "semver": "^7.0.0",
+        "teeny-request": "^7.0.0"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
+          "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
+          "requires": {
+            "@google-cloud/projectify": "^2.0.0",
+            "@google-cloud/promisify": "^2.0.0",
+            "arrify": "^2.0.1",
+            "duplexify": "^4.1.1",
+            "ent": "^2.2.0",
+            "extend": "^3.0.2",
+            "google-auth-library": "^6.1.1",
+            "retry-request": "^4.1.1",
+            "teeny-request": "^7.0.0"
+          }
+        },
+        "@google-cloud/projectify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
+          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ=="
+        },
+        "@google-cloud/promisify": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
+          "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
+        },
+        "@types/long": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+          "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "@types/node": {
+          "version": "13.13.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.42.tgz",
+          "integrity": "sha512-g+w2QgbW7k2CWLOXzQXbO37a7v5P9ObPvYahKphdBLV5aqpbVZRhTpWCT0SMRqX1i30Aig791ZmIM2fJGL2S8A=="
+        },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "gaxios": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+          "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "6.1.6",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+          "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+          "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+          "requires": {
+            "node-forge": "^0.10.0"
+          }
+        },
+        "gtoken": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "google-p12-pem": "^3.0.3",
+            "jws": "^4.0.0"
+          }
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        },
+        "protobufjs": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+          "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": "^13.7.0",
+            "long": "^4.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "teeny-request": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+          "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+          "requires": {
+            "http-proxy-agent": "^4.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "node-fetch": "^2.6.1",
+            "stream-events": "^1.0.5",
+            "uuid": "^8.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@google-cloud/projectify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
@@ -310,6 +716,229 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
       "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
+    },
+    "@google-cloud/trace-agent": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.3.tgz",
+      "integrity": "sha512-f+5DX7n6QpDlHA+4kr81z69SLAdrlvd9T8skqCMgnYvtXx14AwzXZyzEDf3jppOYzYoqPPJv8XYiyYHHmYD0BA==",
+      "requires": {
+        "@google-cloud/common": "^3.0.0",
+        "@opencensus/propagation-stackdriver": "0.0.22",
+        "builtin-modules": "^3.0.0",
+        "console-log-level": "^1.4.0",
+        "continuation-local-storage": "^3.2.1",
+        "extend": "^3.0.2",
+        "gcp-metadata": "^4.0.0",
+        "google-auth-library": "^7.0.0",
+        "hex2dec": "^1.0.1",
+        "is": "^3.2.0",
+        "methods": "^1.1.1",
+        "require-in-the-middle": "^5.0.0",
+        "semver": "^7.0.0",
+        "shimmer": "^1.2.0",
+        "source-map-support": "^0.5.16",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "@google-cloud/common": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
+          "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
+          "requires": {
+            "@google-cloud/projectify": "^2.0.0",
+            "@google-cloud/promisify": "^2.0.0",
+            "arrify": "^2.0.1",
+            "duplexify": "^4.1.1",
+            "ent": "^2.2.0",
+            "extend": "^3.0.2",
+            "google-auth-library": "^6.1.1",
+            "retry-request": "^4.1.1",
+            "teeny-request": "^7.0.0"
+          },
+          "dependencies": {
+            "google-auth-library": {
+              "version": "6.1.6",
+              "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+              "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+              "requires": {
+                "arrify": "^2.0.0",
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "fast-text-encoding": "^1.0.0",
+                "gaxios": "^4.0.0",
+                "gcp-metadata": "^4.2.0",
+                "gtoken": "^5.0.4",
+                "jws": "^4.0.0",
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "@google-cloud/projectify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
+          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ=="
+        },
+        "@google-cloud/promisify": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
+          "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
+        },
+        "@opencensus/core": {
+          "version": "0.0.22",
+          "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.22.tgz",
+          "integrity": "sha512-ErazJtivjceNoOZI1bG9giQ6cWS45J4i6iPUtlp7dLNu58OLs/v+CD0FsaPCh47XgPxAI12vbBE8Ec09ViwHNA==",
+          "requires": {
+            "continuation-local-storage": "^3.2.1",
+            "log-driver": "^1.2.7",
+            "semver": "^7.0.0",
+            "shimmer": "^1.2.0",
+            "uuid": "^8.0.0"
+          }
+        },
+        "@opencensus/propagation-stackdriver": {
+          "version": "0.0.22",
+          "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.0.22.tgz",
+          "integrity": "sha512-eBvf/ihb1mN8Yz/ASkz8nHzuMKqygu77+VNnUeR0yEh3Nj+ykB8VVR6lK+NAFXo1Rd1cOsTmgvuXAZgDAGleQQ==",
+          "requires": {
+            "@opencensus/core": "^0.0.22",
+            "hex2dec": "^1.0.1",
+            "uuid": "^8.0.0"
+          }
+        },
+        "bignumber.js": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "gaxios": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "gcp-metadata": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+          "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.2.tgz",
+          "integrity": "sha512-vjyNZR3pDLC0u7GHLfj+Hw9tGprrJwoMwkYGqURCXYITjCrP9HprOyxVV+KekdLgATtWGuDkQG2MTh0qpUPUgg==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
+            "gtoken": "^5.0.4",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-p12-pem": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+          "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+          "requires": {
+            "node-forge": "^0.10.0"
+          }
+        },
+        "gtoken": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+          "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+          "requires": {
+            "gaxios": "^4.0.0",
+            "google-p12-pem": "^3.0.3",
+            "jws": "^4.0.0"
+          }
+        },
+        "json-bigint": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+          "requires": {
+            "bignumber.js": "^9.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "teeny-request": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
+          "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
+          "requires": {
+            "http-proxy-agent": "^4.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "node-fetch": "^2.6.1",
+            "stream-events": "^1.0.5",
+            "uuid": "^8.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "@grpc/grpc-js": {
       "version": "1.0.5",
@@ -365,9 +994,9 @@
       }
     },
     "@overleaf/metrics": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@overleaf/metrics/-/metrics-3.4.1.tgz",
-      "integrity": "sha512-OgjlzuC+2gPdIEDHhmd9LDMu01tk1ln0cJhw1727BZ+Wgf2Z1hjuHRt4JeCkf+PFTHwJutVYT8v6IGPpNEPtbg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@overleaf/metrics/-/metrics-3.5.1.tgz",
+      "integrity": "sha512-RLHxkMF7Y3725L3QwXo9cIn2gGobsMYUGuxKxg7PVMrPTMsomHEMeG7StOxCO7ML1Z/BwB/9nsVYNrsRdAJtKg==",
       "requires": {
         "@google-cloud/debug-agent": "^5.1.2",
         "@google-cloud/profiler": "^4.0.3",
@@ -376,360 +1005,6 @@
         "prom-client": "^11.1.3",
         "underscore": "~1.6.0",
         "yn": "^3.1.1"
-      },
-      "dependencies": {
-        "@google-cloud/common": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
-          "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
-          "requires": {
-            "@google-cloud/projectify": "^2.0.0",
-            "@google-cloud/promisify": "^2.0.0",
-            "arrify": "^2.0.1",
-            "duplexify": "^4.1.1",
-            "ent": "^2.2.0",
-            "extend": "^3.0.2",
-            "google-auth-library": "^6.1.1",
-            "retry-request": "^4.1.1",
-            "teeny-request": "^7.0.0"
-          }
-        },
-        "@google-cloud/debug-agent": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/@google-cloud/debug-agent/-/debug-agent-5.1.3.tgz",
-          "integrity": "sha512-WbzeEz4MvPlM7DX2QBsPcWgF62u7LSQv/oMYPl0L+TddTebqjDKiVXwxpzWk61NIfcKiet3dyCbPIt3N5o8XPQ==",
-          "requires": {
-            "@google-cloud/common": "^3.0.0",
-            "acorn": "^8.0.0",
-            "coffeescript": "^2.0.0",
-            "console-log-level": "^1.4.0",
-            "extend": "^3.0.2",
-            "findit2": "^2.2.3",
-            "gcp-metadata": "^4.0.0",
-            "p-limit": "^3.0.1",
-            "semver": "^7.0.0",
-            "source-map": "^0.6.1",
-            "split": "^1.0.0"
-          }
-        },
-        "@google-cloud/profiler": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@google-cloud/profiler/-/profiler-4.1.0.tgz",
-          "integrity": "sha512-9e1zXRctLSUHAoAsFGwE4rS28fr0siiG+jXl5OpwTK8ZAUlxb70aosHaZGdsv8YXrYKjuiufjRZ/OXCs0XLI9g==",
-          "requires": {
-            "@google-cloud/common": "^3.0.0",
-            "@types/console-log-level": "^1.4.0",
-            "@types/semver": "^7.0.0",
-            "console-log-level": "^1.4.0",
-            "delay": "^4.0.1",
-            "extend": "^3.0.2",
-            "gcp-metadata": "^4.0.0",
-            "parse-duration": "^0.4.4",
-            "pprof": "3.0.0",
-            "pretty-ms": "^7.0.0",
-            "protobufjs": "~6.10.0",
-            "semver": "^7.0.0",
-            "teeny-request": "^7.0.0"
-          }
-        },
-        "@google-cloud/projectify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.0.1.tgz",
-          "integrity": "sha512-ZDG38U/Yy6Zr21LaR3BTiiLtpJl6RkPS/JwoRT453G+6Q1DhlV0waNf8Lfu+YVYGIIxgKnLayJRfYlFJfiI8iQ=="
-        },
-        "@google-cloud/promisify": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
-          "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
-        },
-        "@google-cloud/trace-agent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.1.tgz",
-          "integrity": "sha512-YTcK0RLN90pLCprg0XC8uV4oAVd79vsXhkcxmEVwiOOYjUDvSrAhb7y/0SY606zgfhJHmUTNb/fZSWEtZP/slQ==",
-          "requires": {
-            "@google-cloud/common": "^3.0.0",
-            "@opencensus/propagation-stackdriver": "0.0.22",
-            "builtin-modules": "^3.0.0",
-            "console-log-level": "^1.4.0",
-            "continuation-local-storage": "^3.2.1",
-            "extend": "^3.0.2",
-            "gcp-metadata": "^4.0.0",
-            "google-auth-library": "^6.0.0",
-            "hex2dec": "^1.0.1",
-            "is": "^3.2.0",
-            "methods": "^1.1.1",
-            "require-in-the-middle": "^5.0.0",
-            "semver": "^7.0.0",
-            "shimmer": "^1.2.0",
-            "source-map-support": "^0.5.16",
-            "uuid": "^8.0.0"
-          }
-        },
-        "@opencensus/core": {
-          "version": "0.0.22",
-          "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.22.tgz",
-          "integrity": "sha512-ErazJtivjceNoOZI1bG9giQ6cWS45J4i6iPUtlp7dLNu58OLs/v+CD0FsaPCh47XgPxAI12vbBE8Ec09ViwHNA==",
-          "requires": {
-            "continuation-local-storage": "^3.2.1",
-            "log-driver": "^1.2.7",
-            "semver": "^7.0.0",
-            "shimmer": "^1.2.0",
-            "uuid": "^8.0.0"
-          }
-        },
-        "@opencensus/propagation-stackdriver": {
-          "version": "0.0.22",
-          "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.0.22.tgz",
-          "integrity": "sha512-eBvf/ihb1mN8Yz/ASkz8nHzuMKqygu77+VNnUeR0yEh3Nj+ykB8VVR6lK+NAFXo1Rd1cOsTmgvuXAZgDAGleQQ==",
-          "requires": {
-            "@opencensus/core": "^0.0.22",
-            "hex2dec": "^1.0.1",
-            "uuid": "^8.0.0"
-          }
-        },
-        "@types/long": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-          "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
-        },
-        "@types/node": {
-          "version": "13.13.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.33.tgz",
-          "integrity": "sha512-1B3GM1yuYsFyEvBb+ljBqWBOylsWDYioZ5wpu8AhXdIhq20neXS7eaSC8GkwHE0yQYGiOIV43lMsgRYTgKZefQ=="
-        },
-        "@types/semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
-        },
-        "acorn": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.4.tgz",
-          "integrity": "sha512-XNP0PqF1XD19ZlLKvB7cMmnZswW4C/03pRHgirB30uSJTaS3A3V1/P4sS3HPvFmjoriPCJQs+JDSbm4bL1TxGQ=="
-        },
-        "bignumber.js": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-          "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
-        },
-        "coffeescript": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
-          "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "duplexify": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
-          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
-          "requires": {
-            "end-of-stream": "^1.4.1",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.1.1",
-            "stream-shift": "^1.0.0"
-          }
-        },
-        "gaxios": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
-          "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.3.0"
-          }
-        },
-        "gcp-metadata": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-          "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-          "requires": {
-            "gaxios": "^4.0.0",
-            "json-bigint": "^1.0.0"
-          }
-        },
-        "google-auth-library": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-          "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
-          "requires": {
-            "arrify": "^2.0.0",
-            "base64-js": "^1.3.0",
-            "ecdsa-sig-formatter": "^1.0.11",
-            "fast-text-encoding": "^1.0.0",
-            "gaxios": "^4.0.0",
-            "gcp-metadata": "^4.2.0",
-            "gtoken": "^5.0.4",
-            "jws": "^4.0.0",
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "google-p12-pem": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-          "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-          "requires": {
-            "node-forge": "^0.10.0"
-          }
-        },
-        "gtoken": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-          "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
-          "requires": {
-            "gaxios": "^4.0.0",
-            "google-p12-pem": "^3.0.3",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
-          }
-        },
-        "json-bigint": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-          "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-          "requires": {
-            "bignumber.js": "^9.0.0"
-          }
-        },
-        "jwa": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-          "requires": {
-            "buffer-equal-constant-time": "1.0.1",
-            "ecdsa-sig-formatter": "1.0.11",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "jws": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-          "requires": {
-            "jwa": "^2.0.0",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "parse-duration": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
-          "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
-        },
-        "pretty-ms": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
-          "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
-          "requires": {
-            "parse-ms": "^2.1.0"
-          }
-        },
-        "protobufjs": {
-          "version": "6.10.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-          "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": "^13.7.0",
-            "long": "^4.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "require-in-the-middle": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz",
-          "integrity": "sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==",
-          "requires": {
-            "debug": "^4.1.1",
-            "module-details-from-path": "^1.0.3",
-            "resolve": "^1.12.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-        },
-        "teeny-request": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.0.1.tgz",
-          "integrity": "sha512-sasJmQ37klOlplL4Ia/786M5YlOcoLGQyq2TE4WHSRupbAuDaQW0PfVxV4MtdBtRJ4ngzS+1qim8zP6Zp35qCw==",
-          "requires": {
-            "http-proxy-agent": "^4.0.0",
-            "https-proxy-agent": "^5.0.0",
-            "node-fetch": "^2.6.1",
-            "stream-events": "^1.0.5",
-            "uuid": "^8.0.0"
-          }
-        },
-        "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        }
       }
     },
     "@overleaf/o-error": {
@@ -897,6 +1172,11 @@
       "version": "10.12.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
       "integrity": "sha1-IOhWUbYv2GZW5Xycm8dxqxVwvFk="
+    },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
     },
     "@typescript-eslint/experimental-utils": {
       "version": "1.13.0",
@@ -1351,9 +1631,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA=="
     },
     "bunyan": {
       "version": "1.8.12",
@@ -1797,9 +2077,9 @@
       }
     },
     "delay": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
-      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3786,6 +4066,25 @@
       "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
       "dev": true
     },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4700,6 +4999,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-duration": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
+      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -4786,6 +5090,11 @@
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
+    "pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
+    },
     "pkg-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -4818,9 +5127,9 @@
           "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
         },
         "@types/node": {
-          "version": "13.13.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.33.tgz",
-          "integrity": "sha512-1B3GM1yuYsFyEvBb+ljBqWBOylsWDYioZ5wpu8AhXdIhq20neXS7eaSC8GkwHE0yQYGiOIV43lMsgRYTgKZefQ=="
+          "version": "13.13.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.42.tgz",
+          "integrity": "sha512-g+w2QgbW7k2CWLOXzQXbO37a7v5P9ObPvYahKphdBLV5aqpbVZRhTpWCT0SMRqX1i30Aig791ZmIM2fJGL2S8A=="
         },
         "debug": {
           "version": "3.2.7",
@@ -4844,14 +5153,14 @@
           }
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "needle": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-          "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+          "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -4882,11 +5191,6 @@
           "requires": {
             "yocto-queue": "^0.1.0"
           }
-        },
-        "pify": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-          "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
         },
         "protobufjs": {
           "version": "6.10.2",
@@ -5552,6 +5856,14 @@
         }
       }
     },
+    "pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "requires": {
+        "parse-ms": "^2.1.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -5868,6 +6180,31 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-in-the-middle": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
+      "integrity": "sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "require-like": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node $NODE_APP_OPTIONS app.js",
     "test:acceptance:_run": "mocha --recursive --reporter spec --timeout 15000 --exit $@ test/acceptance/js",
     "test:acceptance": "npm run test:acceptance:_run -- --grep=$MOCHA_GREP",
-    "test:unit:_run": "mocha --exit --recursive --reporter spec $@ test/unit/js",
+    "test:unit:_run": "mocha --recursive --reporter spec $@ test/unit/js",
     "test:unit": "npm run test:unit:_run -- --grep=$MOCHA_GREP",
     "nodemon": "nodemon --config nodemon.json",
     "lint": "node_modules/.bin/eslint --max-warnings 0 .",
@@ -19,7 +19,7 @@
   },
   "author": "James Allen <james@sharelatex.com>",
   "dependencies": {
-    "@overleaf/metrics": "^3.4.1",
+    "@overleaf/metrics": "^3.5.1",
     "async": "3.2.0",
     "body-parser": "^1.19.0",
     "diskusage": "^1.1.3",


### PR DESCRIPTION
### Description

Re-Land https://github.com/overleaf/clsi/pull/210

For https://github.com/overleaf/issues/issues/3764

- 3.5.1

  - drop background process

- 3.5.0

  - decaf cleanup
  - add support for swagger-tools router

####

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3764

#### Potential Impact

High. Incomplete metrics collection.

#### Manual testing performed

- create a new project
- open a project in the editor
- make changes to a document, reload the editor to check persistence
- compile a project
- open the history tab in the editor
- repeat testing with legacy history service
- all services seem to be running fine in the dev-env
- request all the `/metrics` endpoints and see many metric lines each

    ```
    dev-environment$ grep -e 127.0.0.1:3 -e 127.0.0.1:40 docker-compose.yml | sed -E 's/.+- (.+):(.+):(.+)/\1:\2/' | xargs -I % sh -c 'echo -n "%: lines=" && curl %/metrics -s | wc -l'
    127.0.0.1:3010: lines=116
    127.0.0.1:3016: lines=242
    127.0.0.1:3003: lines=510
    127.0.0.1:3009: lines=212
    127.0.0.1:3022: lines=141
    127.0.0.1:3026: lines=224
    127.0.0.1:3036: lines=128
    127.0.0.1:3042: lines=161
    127.0.0.1:3015: lines=190
    127.0.0.1:3054: lines=405
    127.0.0.1:4000: lines=800
    127.0.0.1:3809: lines=10   <- 404 from webpack, which is fine
    127.0.0.1:3013: lines=306
    127.0.0.1:3005: lines=162
    127.0.0.1:3007: lines=116
    127.0.0.1:3050: lines=132
    127.0.0.1:3046: lines=153
    127.0.0.1:3040: lines=153
    127.0.0.1:3020: lines=153
    127.0.0.1:3002: lines=232
    127.0.0.1:3030: lines=264
    127.0.0.1:3100: lines=201
    ```
