### PR TITLE
[misc] consume and validate a custom imageName for synctex requests

### DIFF
--- a/test/acceptance/js/AllowedImageNames.js
+++ b/test/acceptance/js/AllowedImageNames.js
@@ -71,6 +71,78 @@ Hello world
     })
   })
 
+  describe('syncToCode', function () {
+    beforeEach(function (done) {
+      Client.compile(this.project_id, this.request, done)
+    })
+    it('should error out with an invalid imageName', function () {
+      Client.syncFromCodeWithImage(
+        this.project_id,
+        'main.tex',
+        3,
+        5,
+        'something/evil:1337',
+        (error, body) => {
+          expect(String(error)).to.include('statusCode=400')
+          expect(body).to.equal('invalid image')
+        }
+      )
+    })
+
+    it('should produce a mapping a valid imageName', function () {
+      Client.syncFromCodeWithImage(
+        this.project_id,
+        'main.tex',
+        3,
+        5,
+        process.env.TEXLIVE_IMAGE,
+        (error, result) => {
+          expect(error).to.not.exist
+          expect(result).to.deep.equal({
+            pdf: [
+              { page: 1, h: 133.77, v: 134.76, height: 6.92, width: 343.71 }
+            ]
+          })
+        }
+      )
+    })
+  })
+
+  describe('syncToPdf', function () {
+    beforeEach(function (done) {
+      Client.compile(this.project_id, this.request, done)
+    })
+    it('should error out with an invalid imageName', function () {
+      Client.syncFromPdfWithImage(
+        this.project_id,
+        'main.tex',
+        100,
+        200,
+        'something/evil:1337',
+        (error, body) => {
+          expect(String(error)).to.include('statusCode=400')
+          expect(body).to.equal('invalid image')
+        }
+      )
+    })
+
+    it('should produce a mapping a valid imageName', function () {
+      Client.syncFromPdfWithImage(
+        this.project_id,
+        1,
+        100,
+        200,
+        process.env.TEXLIVE_IMAGE,
+        (error, result) => {
+          expect(error).to.not.exist
+          expect(result).to.deep.equal({
+            code: [{ file: 'main.tex', line: 3, column: -1 }]
+          })
+        }
+      )
+    })
+  })
+
   describe('wordcount', function () {
     beforeEach(function (done) {
       Client.compile(this.project_id, this.request, done)
@@ -80,8 +152,9 @@ Hello world
         this.project_id,
         'main.tex',
         'something/evil:1337',
-        (error, result) => {
+        (error, body) => {
           expect(String(error)).to.include('statusCode=400')
+          expect(body).to.equal('invalid image')
         }
       )
     })

--- a/test/acceptance/js/SynctexTests.js
+++ b/test/acceptance/js/SynctexTests.js
@@ -100,9 +100,7 @@ Hello world
           3,
           5,
           (error, body) => {
-            if (error != null) {
-              throw error
-            }
+            expect(String(error)).to.include('statusCode=404')
             expect(body).to.equal('Not Found')
             return done()
           }
@@ -117,9 +115,7 @@ Hello world
           100,
           200,
           (error, body) => {
-            if (error != null) {
-              throw error
-            }
+            expect(String(error)).to.include('statusCode=404')
             expect(body).to.equal('Not Found')
             return done()
           }
@@ -160,9 +156,7 @@ Hello world
           3,
           5,
           (error, body) => {
-            if (error != null) {
-              throw error
-            }
+            expect(String(error)).to.include('statusCode=404')
             expect(body).to.equal('Not Found')
             return done()
           }
@@ -177,9 +171,7 @@ Hello world
           100,
           200,
           (error, body) => {
-            if (error != null) {
-              throw error
-            }
+            expect(String(error)).to.include('statusCode=404')
             expect(body).to.equal('Not Found')
             return done()
           }

--- a/test/acceptance/js/helpers/Client.js
+++ b/test/acceptance/js/helpers/Client.js
@@ -69,6 +69,10 @@ module.exports = Client = {
   },
 
   syncFromCode(project_id, file, line, column, callback) {
+    Client.syncFromCodeWithImage(project_id, file, line, column, '', callback)
+  },
+
+  syncFromCodeWithImage(project_id, file, line, column, imageName, callback) {
     if (callback == null) {
       callback = function (error, pdfPositions) {}
     }
@@ -76,6 +80,7 @@ module.exports = Client = {
       {
         url: `${this.host}/project/${project_id}/sync/code`,
         qs: {
+          imageName,
           file,
           line,
           column
@@ -86,12 +91,19 @@ module.exports = Client = {
         if (error != null) {
           return callback(error)
         }
+        if (response.statusCode !== 200) {
+          return callback(new Error(`statusCode=${response.statusCode}`), body)
+        }
         return callback(null, body)
       }
     )
   },
 
   syncFromPdf(project_id, page, h, v, callback) {
+    Client.syncFromPdfWithImage(project_id, page, h, v, '', callback)
+  },
+
+  syncFromPdfWithImage(project_id, page, h, v, imageName, callback) {
     if (callback == null) {
       callback = function (error, pdfPositions) {}
     }
@@ -99,6 +111,7 @@ module.exports = Client = {
       {
         url: `${this.host}/project/${project_id}/sync/pdf`,
         qs: {
+          imageName,
           page,
           h,
           v
@@ -108,6 +121,9 @@ module.exports = Client = {
       (error, response, body) => {
         if (error != null) {
           return callback(error)
+        }
+        if (response.statusCode !== 200) {
+          return callback(new Error(`statusCode=${response.statusCode}`), body)
         }
         return callback(null, body)
       }
@@ -208,7 +224,7 @@ module.exports = Client = {
           return callback(error)
         }
         if (response.statusCode !== 200) {
-          return callback(new Error(`statusCode=${response.statusCode}`))
+          return callback(new Error(`statusCode=${response.statusCode}`), body)
         }
         return callback(null, JSON.parse(body))
       }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3170
papercut 27
^ a bit more than a papercut.

This PR is adding request parsing/validation and passing around of a custom imageName for synctex requests.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3170
papercut 27

### Review

The handling is very similar to the `image` parameter handling in the wordcount handling. I've aligned the query flag for the two synctex endpoints with the internal label in mongo and in the compile request body. 

The PR is best reviewed with whitespace changes ignored due to a few indentation changes from adding parameter to functions.

#### Potential Impact

Low. It handles a missing flag just fine.

#### Manual Testing Performed

- see added tests
- setup dev-env like prod https://github.com/overleaf/dev-environment/pull/466
- set image name to the evil image
- try sync-to-code/pdf --- fails
- switch to a valid image
- see the imageName in the query parameter in `$ docker-compose logs --tail=10 clsi`
