### PR TITLE
add hash benchmark script

### DIFF
--- a/test/bench/hashbench.js
+++ b/test/bench/hashbench.js
@@ -33,6 +33,8 @@ function test(hashType, filePath, callback) {
             return callback(err)
           }
           console.log(
+            'uvthreads',
+            process.env.UV_THREADPOOL_SIZE,
             filePath,
             'hashType',
             hashType,

--- a/test/bench/hashbench.js
+++ b/test/bench/hashbench.js
@@ -1,0 +1,71 @@
+const ContentCacheManager = require('../../app/js/ContentCacheManager')
+const fs = require('fs')
+const crypto = require('crypto')
+const path = require('path')
+const os = require('os')
+const async = require('async')
+const _createHash = crypto.createHash
+
+const files = process.argv.slice(2)
+
+function test(hashType, filePath, callback) {
+  // override the default hash in ContentCacheManager
+  crypto.createHash = function (hash) {
+    if (hashType === 'hmac-sha1') {
+      return crypto.createHmac('sha1', 'a secret')
+    }
+    hash = hashType
+    return _createHash(hash)
+  }
+  fs.mkdtemp(path.join(os.tmpdir(), 'pdfcache'), (err, dir) => {
+    if (err) {
+      return callback(err)
+    }
+    const t0 = process.hrtime.bigint()
+    ContentCacheManager.update(dir, filePath, (x) => {
+      const t1 = process.hrtime.bigint()
+      const cold = Number(t1 - t0) / 1e6
+      ContentCacheManager.update(dir, filePath, (x) => {
+        const t2 = process.hrtime.bigint()
+        const warm = Number(t2 - t1) / 1e6
+        fs.rmdir(dir, { recursive: true }, (err) => {
+          if (err) {
+            return callback(err)
+          }
+          console.log(
+            filePath,
+            'hashType',
+            hashType,
+            'cold-start',
+            cold.toFixed(2),
+            'ms',
+            'warm-start',
+            warm.toFixed(2),
+            'ms'
+          )
+          callback(null, [hashType, cold, warm])
+        })
+      })
+    })
+  })
+}
+
+var jobs = []
+files.forEach((file) => {
+  jobs.push((cb) => {
+    test('md5', file, cb)
+  })
+  jobs.push((cb) => {
+    test('sha1', file, cb)
+  })
+  jobs.push((cb) => {
+    test('hmac-sha1', file, cb)
+  })
+  jobs.push((cb) => {
+    test('sha256', file, cb)
+  })
+})
+
+async.series(jobs, () => {
+  console.log('DONE')
+})

--- a/test/bench/hashbench.js
+++ b/test/bench/hashbench.js
@@ -68,13 +68,6 @@ files.forEach((file) => {
   })
 })
 
-async.timesSeries(
-  10,
-  (n, cb) => {
-    console.log('run', n)
-    async.series(jobs, cb)
-  },
-  () => {
-    console.log('DONE')
-  }
-)
+async.timesSeries(10, (n, cb) => {
+  async.series(jobs, cb)
+})

--- a/test/bench/hashbench.js
+++ b/test/bench/hashbench.js
@@ -66,6 +66,13 @@ files.forEach((file) => {
   })
 })
 
-async.series(jobs, () => {
-  console.log('DONE')
-})
+async.timesSeries(
+  10,
+  (n, cb) => {
+    console.log('run', n)
+    async.series(jobs, cb)
+  },
+  () => {
+    console.log('DONE')
+  }
+)


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Adds a benchmark script for the content hashing

#### Screenshots

NA

#### Related Issues / PRs



### Review

I notice we are using the default value of 64k for the highWatermark on fs.createReadStream.  Increasing it to 1MB helps, there's no benefit beyond that though.

With default highWatermark on fs.createReadStream
```
root@clsi-reg-e2-a-d4sz-ctr:/app# time node test/bench/hashbench.js /app/compiles/AMS55.pdf 
/app/compiles/AMS55.pdf hashType md5 cold-start 1755.19 ms warm-start 651.24 ms
/app/compiles/AMS55.pdf hashType sha1 cold-start 1324.65 ms warm-start 443.96 ms
/app/compiles/AMS55.pdf hashType hmac-sha1 cold-start 1394.18 ms warm-start 537.54 ms
/app/compiles/AMS55.pdf hashType sha256 cold-start 1305.88 ms warm-start 420.96 ms
DONE

real	0m8.477s
user	0m6.000s
sys	0m4.436s
```

With highWatermark:1024*1024 on fs.createReadStream the runtime is reduced by 20%, mainly due to the reduction in `user` time (-1.4s) rather than `sys` time (-0.56s).  It means `node` has less work to do switching between the chunks.

```
root@clsi-reg-e2-a-d4sz-ctr:/app# time node test/bench/hashbench.js /app/compiles/AMS55.pdf 
/app/compiles/AMS55.pdf hashType md5 cold-start 1354.09 ms warm-start 542.39 ms
/app/compiles/AMS55.pdf hashType sha1 cold-start 1079.00 ms warm-start 390.91 ms
/app/compiles/AMS55.pdf hashType hmac-sha1 cold-start 1163.47 ms warm-start 406.72 ms
/app/compiles/AMS55.pdf hashType sha256 cold-start 1052.26 ms warm-start 363.69 ms
DONE

real	0m6.852s
user	0m4.601s
sys	0m3.877s
```


#### Potential Impact

NA

#### Manual Testing Performed

NA

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA