### PR TITLE
[misc] add metrics for pdf caching and dark mode for compute only

### DIFF
--- a/app/js/CompileController.js
+++ b/app/js/CompileController.js
@@ -49,7 +49,9 @@ module.exports = CompileController = {
           }
           return CompileManager.doCompileWithLock(request, function (
             error,
-            outputFiles
+            outputFiles,
+            stats,
+            timings
           ) {
             let code, status
             if (outputFiles == null) {
@@ -118,6 +120,8 @@ module.exports = CompileController = {
               compile: {
                 status,
                 error: (error != null ? error.message : undefined) || error,
+                stats,
+                timings,
                 outputFiles: outputFiles.map((file) => {
                   const record = {
                     url:

--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -249,11 +249,13 @@ module.exports = CompileManager = {
                 return callback(error)
               }
               Metrics.inc('compiles-succeeded')
+              stats = stats || {}
               const object = stats || {}
               for (metric_key in object) {
                 metric_value = object[metric_key]
                 Metrics.count(metric_key, metric_value)
               }
+              timings = timings || {}
               const object1 = timings || {}
               for (metric_key in object1) {
                 metric_value = object1[metric_key]
@@ -301,7 +303,12 @@ module.exports = CompileManager = {
                     outputFiles,
                     compileDir,
                     outputDir,
-                    (error, newOutputFiles) => callback(null, newOutputFiles)
+                    (err, newOutputFiles) => {
+                      // Emit compile time.
+                      timings.compile = ts
+
+                      callback(null, newOutputFiles, stats, timings)
+                    }
                   )
                 }
               )

--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -34,8 +34,7 @@ const os = require('os')
 const async = require('async')
 const Errors = require('./Errors')
 const CommandRunner = require('./CommandRunner')
-
-const ONE_MB = 1024 * 1024
+const { emitPdfStats } = require('./ContentCacheMetrics')
 
 const getCompileName = function (project_id, user_id) {
   if (user_id != null) {
@@ -50,79 +49,6 @@ const getCompileDir = (project_id, user_id) =>
 
 const getOutputDir = (project_id, user_id) =>
   Path.join(Settings.path.outputDir, getCompileName(project_id, user_id))
-
-function emitPdfStats(stats, timings) {
-  if (timings['compute-pdf-caching']) {
-    emitPdfCachingStats(stats, timings)
-  } else {
-    // How much bandwidth will the pdf incur when downloaded in full?
-    Metrics.summary('pdf-bandwidth', stats['pdf-size'])
-  }
-}
-
-function emitPdfCachingStats(stats, timings) {
-  if (!stats['pdf-size']) return // double check
-
-  // How large is the overhead of hashing up-front?
-  const fraction =
-    timings.compileE2E - timings['compute-pdf-caching'] !== 0
-      ? timings.compileE2E /
-        (timings.compileE2E - timings['compute-pdf-caching'])
-      : 1
-  Metrics.summary('overhead-compute-pdf-ranges', fraction * 100 - 100)
-
-  // How does the hashing scale to pdf size in MB?
-  Metrics.timing(
-    'compute-pdf-caching-relative-to-pdf-size',
-    timings['compute-pdf-caching'] / (stats['pdf-size'] / ONE_MB)
-  )
-  if (stats['pdf-caching-total-ranges-size']) {
-    // How does the hashing scale to total ranges size in MB?
-    Metrics.timing(
-      'compute-pdf-caching-relative-to-total-ranges-size',
-      timings['compute-pdf-caching'] /
-        (stats['pdf-caching-total-ranges-size'] / ONE_MB)
-    )
-    // How fast is the hashing per range on average?
-    Metrics.timing(
-      'compute-pdf-caching-relative-to-ranges-count',
-      timings['compute-pdf-caching'] / stats['pdf-caching-n-ranges']
-    )
-
-    // How many ranges are new?
-    Metrics.summary(
-      'new-pdf-ranges-relative-to-total-ranges',
-      (stats['pdf-caching-n-new-ranges'] / stats['pdf-caching-n-ranges']) * 100
-    )
-  }
-
-  // How much content is cacheable?
-  Metrics.summary(
-    'cacheable-ranges-to-pdf-size',
-    (stats['pdf-caching-total-ranges-size'] / stats['pdf-size']) * 100
-  )
-
-  const sizeWhenDownloadedInFull =
-    // All of the pdf
-    stats['pdf-size'] -
-    // These ranges are potentially cached.
-    stats['pdf-caching-total-ranges-size'] +
-    // These ranges are not cached.
-    stats['pdf-caching-new-ranges-size']
-
-  // How much bandwidth can we save when downloading the pdf in full?
-  Metrics.summary(
-    'pdf-bandwidth-savings',
-    100 - (sizeWhenDownloadedInFull / stats['pdf-size']) * 100
-  )
-
-  // How much bandwidth will the pdf incur when downloaded in full?
-  Metrics.summary('pdf-bandwidth', sizeWhenDownloadedInFull)
-
-  // How much space do the ranges use?
-  // This will accumulate the ranges size over time, skipping already written ranges.
-  Metrics.summary('pdf-ranges-disk-size', stats['pdf-caching-new-ranges-size'])
-}
 
 module.exports = CompileManager = {
   doCompileWithLock(request, callback) {

--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -304,6 +304,17 @@ module.exports = CompileManager = {
                     compileDir,
                     outputDir,
                     (err, newOutputFiles) => {
+                      if (err) {
+                        const {
+                          project_id: projectId,
+                          user_id: userId
+                        } = request
+                        logger.err(
+                          { projectId, userId, err },
+                          'failed to save output files'
+                        )
+                      }
+
                       // Emit compile time.
                       timings.compile = ts
 

--- a/app/js/ContentCacheManager.js
+++ b/app/js/ContentCacheManager.js
@@ -6,6 +6,7 @@ const { callbackify } = require('util')
 const fs = require('fs')
 const crypto = require('crypto')
 const Path = require('path')
+const Settings = require('settings-sharelatex')
 
 // in prod, this value could get bumped -- balance between bandwidth vs req/s
 const MIN_CHUNK_SIZE = 1024
@@ -101,6 +102,10 @@ async function writePdfStream(dir, hash, buffers) {
     return false
   } catch (e) {}
   const file = await fs.promises.open(filename, 'w')
+  if (Settings.enablePdfCachingDark) {
+    // Write an empty file in dark mode.
+    buffers = []
+  }
   try {
     for (const buffer of buffers) {
       await file.write(buffer)

--- a/app/js/ContentCacheMetrics.js
+++ b/app/js/ContentCacheMetrics.js
@@ -1,0 +1,80 @@
+const Metrics = require('./Metrics')
+
+const ONE_MB = 1024 * 1024
+
+function emitPdfStats(stats, timings) {
+  if (timings['compute-pdf-caching']) {
+    emitPdfCachingStats(stats, timings)
+  } else {
+    // How much bandwidth will the pdf incur when downloaded in full?
+    Metrics.summary('pdf-bandwidth', stats['pdf-size'])
+  }
+}
+
+function emitPdfCachingStats(stats, timings) {
+  if (!stats['pdf-size']) return // double check
+
+  // How large is the overhead of hashing up-front?
+  const fraction =
+    timings.compileE2E - timings['compute-pdf-caching'] !== 0
+      ? timings.compileE2E /
+        (timings.compileE2E - timings['compute-pdf-caching'])
+      : 1
+  Metrics.summary('overhead-compute-pdf-ranges', fraction * 100 - 100)
+
+  // How does the hashing scale to pdf size in MB?
+  Metrics.timing(
+    'compute-pdf-caching-relative-to-pdf-size',
+    timings['compute-pdf-caching'] / (stats['pdf-size'] / ONE_MB)
+  )
+  if (stats['pdf-caching-total-ranges-size']) {
+    // How does the hashing scale to total ranges size in MB?
+    Metrics.timing(
+      'compute-pdf-caching-relative-to-total-ranges-size',
+      timings['compute-pdf-caching'] /
+        (stats['pdf-caching-total-ranges-size'] / ONE_MB)
+    )
+    // How fast is the hashing per range on average?
+    Metrics.timing(
+      'compute-pdf-caching-relative-to-ranges-count',
+      timings['compute-pdf-caching'] / stats['pdf-caching-n-ranges']
+    )
+
+    // How many ranges are new?
+    Metrics.summary(
+      'new-pdf-ranges-relative-to-total-ranges',
+      (stats['pdf-caching-n-new-ranges'] / stats['pdf-caching-n-ranges']) * 100
+    )
+  }
+
+  // How much content is cacheable?
+  Metrics.summary(
+    'cacheable-ranges-to-pdf-size',
+    (stats['pdf-caching-total-ranges-size'] / stats['pdf-size']) * 100
+  )
+
+  const sizeWhenDownloadedInFull =
+    // All of the pdf
+    stats['pdf-size'] -
+    // These ranges are potentially cached.
+    stats['pdf-caching-total-ranges-size'] +
+    // These ranges are not cached.
+    stats['pdf-caching-new-ranges-size']
+
+  // How much bandwidth can we save when downloading the pdf in full?
+  Metrics.summary(
+    'pdf-bandwidth-savings',
+    100 - (sizeWhenDownloadedInFull / stats['pdf-size']) * 100
+  )
+
+  // How much bandwidth will the pdf incur when downloaded in full?
+  Metrics.summary('pdf-bandwidth', sizeWhenDownloadedInFull)
+
+  // How much space do the ranges use?
+  // This will accumulate the ranges size over time, skipping already written ranges.
+  Metrics.summary('pdf-ranges-disk-size', stats['pdf-caching-new-ranges-size'])
+}
+
+module.exports = {
+  emitPdfStats
+}

--- a/app/js/OutputCacheManager.js
+++ b/app/js/OutputCacheManager.js
@@ -22,6 +22,7 @@ const logger = require('logger-sharelatex')
 const _ = require('lodash')
 const Settings = require('settings-sharelatex')
 const crypto = require('crypto')
+const Metrics = require('./Metrics')
 
 const OutputFileOptimiser = require('./OutputFileOptimiser')
 const ContentCacheManager = require('./ContentCacheManager')
@@ -61,7 +62,13 @@ module.exports = OutputCacheManager = {
     })
   },
 
-  saveOutputFiles(request, outputFiles, compileDir, outputDir, callback) {
+  saveOutputFiles(
+    { request, stats, timings },
+    outputFiles,
+    compileDir,
+    outputDir,
+    callback
+  ) {
     if (callback == null) {
       callback = function (error) {}
     }
@@ -78,14 +85,25 @@ module.exports = OutputCacheManager = {
           if (err != null) {
             return callback(err)
           }
-          if (!Settings.enablePdfCaching || !request.enablePdfCaching) {
-            return callback(null, result)
-          }
-          OutputCacheManager.saveStreamsInContentDir(
+          OutputCacheManager.collectOutputPdfSize(
             result,
-            compileDir,
             outputDir,
-            callback
+            stats,
+            (err, result) => {
+              if (err) return callback(err, result)
+
+              if (!Settings.enablePdfCaching || !request.enablePdfCaching) {
+                return callback(null, result)
+              }
+
+              OutputCacheManager.saveStreamsInContentDir(
+                { stats, timings },
+                result,
+                compileDir,
+                outputDir,
+                callback
+              )
+            }
           )
         }
       )
@@ -221,10 +239,34 @@ module.exports = OutputCacheManager = {
     })
   },
 
-  saveStreamsInContentDir(outputFiles, compileDir, outputDir, callback) {
+  collectOutputPdfSize(outputFiles, outputDir, stats, callback) {
+    const outputFile = outputFiles.find((x) => x.path === 'output.pdf')
+    if (!outputFile) return callback(null, outputFiles)
+    const outputFilePath = Path.join(
+      outputDir,
+      OutputCacheManager.path(outputFile.build, outputFile.path)
+    )
+    fs.stat(outputFilePath, (err, stat) => {
+      if (err) return callback(err, outputFiles)
+
+      outputFile.size = stat.size
+      stats['pdf-size'] = outputFile.size
+      callback(null, outputFiles)
+    })
+  },
+
+  saveStreamsInContentDir(
+    { stats, timings },
+    outputFiles,
+    compileDir,
+    outputDir,
+    callback
+  ) {
     const cacheRoot = Path.join(outputDir, OutputCacheManager.CONTENT_SUBDIR)
     // check if content dir exists
     OutputCacheManager.ensureContentDir(cacheRoot, function (err, contentDir) {
+      if (err) return callback(err, outputFiles)
+
       const outputFile = outputFiles.find((x) => x.path === 'output.pdf')
       if (outputFile) {
         outputFile.contentId = Path.basename(contentDir)
@@ -233,21 +275,27 @@ module.exports = OutputCacheManager = {
           outputDir,
           OutputCacheManager.path(outputFile.build, outputFile.path)
         )
+        const timer = new Metrics.Timer('compute-pdf-ranges')
         ContentCacheManager.update(contentDir, outputFilePath, function (
           err,
-          contentRanges
+          ranges
         ) {
-          if (err) {
-            return callback(err)
-          }
+          if (err) return callback(err, outputFiles)
+          const [contentRanges, newContentRanges] = ranges
+
           outputFile.ranges = contentRanges
-          fs.stat(outputFilePath, (err, stat) => {
-            if (err) {
-              return callback(err)
-            }
-            outputFile.size = stat.size
-            callback(null, outputFiles)
-          })
+          timings['compute-pdf-caching'] = timer.done()
+          stats['pdf-caching-n-ranges'] = contentRanges.length
+          stats['pdf-caching-total-ranges-size'] = contentRanges.reduce(
+            (sum, next) => sum + (next.end - next.start),
+            0
+          )
+          stats['pdf-caching-n-new-ranges'] = newContentRanges.length
+          stats['pdf-caching-new-ranges-size'] = newContentRanges.reduce(
+            (sum, next) => sum + (next.end - next.start),
+            0
+          )
+          callback(null, outputFiles)
         })
       } else {
         callback(null, outputFiles)

--- a/app/js/OutputCacheManager.js
+++ b/app/js/OutputCacheManager.js
@@ -269,7 +269,6 @@ module.exports = OutputCacheManager = {
 
       const outputFile = outputFiles.find((x) => x.path === 'output.pdf')
       if (outputFile) {
-        outputFile.contentId = Path.basename(contentDir)
         // possibly we should copy the file from the build dir here
         const outputFilePath = Path.join(
           outputDir,
@@ -283,7 +282,14 @@ module.exports = OutputCacheManager = {
           if (err) return callback(err, outputFiles)
           const [contentRanges, newContentRanges] = ranges
 
-          outputFile.ranges = contentRanges
+          if (Settings.enablePdfCachingDark) {
+            // In dark mode we are doing the computation only and do not emit
+            //  any ranges to the frontend.
+          } else {
+            outputFile.contentId = Path.basename(contentDir)
+            outputFile.ranges = contentRanges
+          }
+
           timings['compute-pdf-caching'] = timer.done()
           stats['pdf-caching-n-ranges'] = contentRanges.length
           stats['pdf-caching-total-ranges-size'] = contentRanges.reduce(

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -65,7 +65,8 @@ module.exports = {
     dsn: process.env.SENTRY_DSN
   },
 
-  enablePdfCaching: process.env.ENABLE_PDF_CACHING === 'true'
+  enablePdfCaching: process.env.ENABLE_PDF_CACHING === 'true',
+  enablePdfCachingDark: process.env.ENABLE_PDF_CACHING_DARK === 'true'
 }
 
 if (process.env.ALLOWED_COMPILE_GROUPS) {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -29,6 +29,7 @@ services:
       NODE_ENV: test
       NODE_OPTIONS: "--unhandled-rejections=strict"
       TEXLIVE_IMAGE:
+      ENABLE_PDF_CACHING: "true"
     command: npm run test:acceptance:_run
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,5 +38,6 @@ services:
       LOG_LEVEL: ERROR
       NODE_ENV: test
       NODE_OPTIONS: "--unhandled-rejections=strict"
+      ENABLE_PDF_CACHING: "true"
     command: npm run --silent test:acceptance
 

--- a/test/acceptance/js/Stats.js
+++ b/test/acceptance/js/Stats.js
@@ -1,0 +1,16 @@
+const request = require('request')
+const Settings = require('settings-sharelatex')
+after(function (done) {
+  request(
+    {
+      url: `${Settings.apis.clsi.url}/metrics`
+    },
+    (err, response, body) => {
+      if (err) return done(err)
+      console.error('-- metrics --')
+      console.error(body)
+      console.error('-- metrics --')
+      done()
+    }
+  )
+})

--- a/test/acceptance/js/helpers/Client.js
+++ b/test/acceptance/js/helpers/Client.js
@@ -30,6 +30,10 @@ module.exports = Client = {
     if (callback == null) {
       callback = function (error, res, body) {}
     }
+    if (data) {
+      // Enable pdf caching unless disabled explicitly.
+      data.options = Object.assign({}, { enablePdfCaching: true }, data.options)
+    }
     return request.post(
       {
         url: `${this.host}/project/${project_id}/compile`,

--- a/test/unit/js/CompileControllerTests.js
+++ b/test/unit/js/CompileControllerTests.js
@@ -113,6 +113,8 @@ describe('CompileController', function () {
       this.ProjectPersistenceManager.markProjectAsJustAccessed = sinon
         .stub()
         .callsArg(1)
+      this.stats = { foo: 1 }
+      this.timings = { bar: 2 }
       this.res.status = sinon.stub().returnsThis()
       return (this.res.send = sinon.stub())
     })
@@ -121,7 +123,7 @@ describe('CompileController', function () {
       beforeEach(function () {
         this.CompileManager.doCompileWithLock = sinon
           .stub()
-          .callsArgWith(1, null, this.output_files)
+          .yields(null, this.output_files, this.stats, this.timings)
         return this.CompileController.compile(this.req, this.res)
       })
 
@@ -150,6 +152,8 @@ describe('CompileController', function () {
             compile: {
               status: 'success',
               error: null,
+              stats: this.stats,
+              timings: this.timings,
               outputFiles: this.output_files.map((file) => {
                 return {
                   url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
@@ -182,7 +186,7 @@ describe('CompileController', function () {
         ]
         this.CompileManager.doCompileWithLock = sinon
           .stub()
-          .callsArgWith(1, null, this.output_files)
+          .yields(null, this.output_files, this.stats, this.timings)
         this.CompileController.compile(this.req, this.res)
       })
 
@@ -193,6 +197,8 @@ describe('CompileController', function () {
             compile: {
               status: 'failure',
               error: null,
+              stats: this.stats,
+              timings: this.timings,
               outputFiles: this.output_files.map((file) => {
                 return {
                   url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
@@ -224,7 +230,10 @@ describe('CompileController', function () {
             compile: {
               status: 'error',
               error: this.message,
-              outputFiles: []
+              outputFiles: [],
+              // JSON.stringify will omit these
+              stats: undefined,
+              timings: undefined
             }
           })
           .should.equal(true)
@@ -248,7 +257,10 @@ describe('CompileController', function () {
             compile: {
               status: 'timedout',
               error: this.message,
-              outputFiles: []
+              outputFiles: [],
+              // JSON.stringify will omit these
+              stats: undefined,
+              timings: undefined
             }
           })
           .should.equal(true)
@@ -270,7 +282,10 @@ describe('CompileController', function () {
             compile: {
               error: null,
               status: 'failure',
-              outputFiles: []
+              outputFiles: [],
+              // JSON.stringify will omit these
+              stats: undefined,
+              timings: undefined
             }
           })
           .should.equal(true)

--- a/test/unit/js/CompileManagerTests.js
+++ b/test/unit/js/CompileManagerTests.js
@@ -71,7 +71,7 @@ describe('CompileManager', function () {
       this.compileDir = `${this.Settings.path.compilesDir}/${this.project_id}-${this.user_id}`
       this.CompileManager.doCompile = sinon
         .stub()
-        .callsArgWith(1, null, this.output_files)
+        .yields(null, this.output_files)
       return (this.LockManager.runWithLock = (lockFile, runner, callback) =>
         runner((err, ...result) => callback(err, ...Array.from(result))))
     })
@@ -172,7 +172,7 @@ describe('CompileManager', function () {
       this.LatexRunner.runLatex = sinon.stub().callsArg(2)
       this.OutputFileFinder.findOutputFiles = sinon
         .stub()
-        .callsArgWith(2, null, this.output_files)
+        .yields(null, this.output_files)
       this.OutputCacheManager.saveOutputFiles = sinon
         .stub()
         .yields(null, this.build_files)


### PR DESCRIPTION
### Description

I've split all the changes into logic commits:

- exercise the pdf caching logic in CI
- expose `stats` and `timings` all the way to the frontend ( https://github.com/overleaf/web-internal/commit/1a601c1816214bb47a49bcb1334be378417c2c92 )
- logging of error from saving output files (and hashing contents)
- the new metrics as discussed in our call
- a _dark mode_ for doing the hashing of ranges only and emitting an empty file to disk, no ranges will be passed to the frontend `ENABLE_PDF_CACHING_DARK="true"`

#### Screenshots

<details>
<summary> dark mode </summary>

```
$ ll clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/1795bfd00ba-80b48763bcb31ac9/
total 69884
drwxr-xr-x 2 me me    4096 May 11 16:12 ./
drwxr-xr-x 3 me me    4096 May 11 16:12 ../
-rw-r--r-- 1 me me 2628690 May 11 16:12 070a75b717e38ec1bb2bba18eef4b57f5f06630d3372eb422706d87b46484e0f
-rw-r--r-- 1 me me 2694814 May 11 16:12 0d41a53c687aadbf7b474d41e3ce7238ed4b7fce1f72ba476c92aa77d6859b72
...
-rw-r--r-- 1 me me  639854 May 11 16:12 fb2abaf06bd4d71d57efff83e9da5b38af83d897968cc57389827f10d800bac3
-rw-r--r-- 1 me me  633477 May 11 16:12 fc73bee0f6f630eb1ebf87451ca98ab8ccb4f2d8e01f98e1626cdc48d71942aa
-rw-r--r-- 1 me me 2361808 May 11 16:12 ff2d76665075c16402c0a686e3d926efed87861c79d36d7f68da9904ddf3961c
$ du clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/ -h
69M     clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/1795bfd00ba-80b48763bcb31ac9
69M     clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/

$ curl 127.0.0.1:3013/metrics -s | grep pdf_ranges_disk_size
# HELP pdf_ranges_disk_size pdf_ranges_disk_size
# TYPE pdf_ranges_disk_size summary
pdf_ranges_disk_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 71478677
pdf_ranges_disk_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="f64c98314762"} 1
```

```
# dark mode
$ du clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/ -h
4.0K    clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/1795bfec0cf-64f65638a1cffc2a
8.0K    clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/
$ ll clsi/output/5fd2393db7aab600269c7212-5efc543e0c774e0026c8598b/content/1795bfec0cf-64f65638a1cffc2a/
total 8
drwxr-xr-x 2 me me 4096 May 11 16:14 ./
drwxr-xr-x 3 me me 4096 May 11 16:14 ../
-rw-r--r-- 1 me me    0 May 11 16:14 070a75b717e38ec1bb2bba18eef4b57f5f06630d3372eb422706d87b46484e0f
-rw-r--r-- 1 me me    0 May 11 16:14 0d41a53c687aadbf7b474d41e3ce7238ed4b7fce1f72ba476c92aa77d6859b72
-rw-r--r-- 1 me me    0 May 11 16:14 1601af6211e6d76d7bfa985c7b52447abdae873ec0c7c6a890eb9069900bf838 
...
-rw-r--r-- 1 me me    0 May 11 16:14 fc73bee0f6f630eb1ebf87451ca98ab8ccb4f2d8e01f98e1626cdc48d71942aa
-rw-r--r-- 1 me me    0 May 11 16:14 ff2d76665075c16402c0a686e3d926efed87861c79d36d7f68da9904ddf3961c

$ curl 127.0.0.1:3013/metrics -s | grep pdf_ranges_disk_size
# HELP pdf_ranges_disk_size pdf_ranges_disk_size
# TYPE pdf_ranges_disk_size summary
pdf_ranges_disk_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1

```
</details>

<details>
<summary> all the new metrics </summary>

```
$ curl 127.0.0.1:3013/metrics -s | grep pdf
# HELP timer_compute_pdf_ranges timer_compute_pdf_ranges
# TYPE timer_compute_pdf_ranges summary
timer_compute_pdf_ranges{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_ranges_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 259
timer_compute_pdf_ranges_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP overhead_compute_pdf_ranges overhead_compute_pdf_ranges
# TYPE overhead_compute_pdf_ranges summary
overhead_compute_pdf_ranges{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
overhead_compute_pdf_ranges_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 4.996141975308646
overhead_compute_pdf_ranges_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP timer_compute_pdf_caching_relative_to_pdf_size timer_compute_pdf_caching_relative_to_pdf_size
# TYPE timer_compute_pdf_caching_relative_to_pdf_size summary
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_pdf_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 3.7981205496781456
timer_compute_pdf_caching_relative_to_pdf_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP timer_compute_pdf_caching_relative_to_total_ranges_size timer_compute_pdf_caching_relative_to_total_ranges_size
# TYPE timer_compute_pdf_caching_relative_to_total_ranges_size summary
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_total_ranges_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 3.7994713304500585
timer_compute_pdf_caching_relative_to_total_ranges_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP timer_compute_pdf_caching_relative_to_ranges_count timer_compute_pdf_caching_relative_to_ranges_count
# TYPE timer_compute_pdf_caching_relative_to_ranges_count summary
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
timer_compute_pdf_caching_relative_to_ranges_count_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 5.886363636363637
timer_compute_pdf_caching_relative_to_ranges_count_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP new_pdf_ranges_relative_to_total_ranges new_pdf_ranges_relative_to_total_ranges
# TYPE new_pdf_ranges_relative_to_total_ranges summary
new_pdf_ranges_relative_to_total_ranges{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
new_pdf_ranges_relative_to_total_ranges_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 100
new_pdf_ranges_relative_to_total_ranges_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP cacheable_ranges_to_pdf_size cacheable_ranges_to_pdf_size
# TYPE cacheable_ranges_to_pdf_size summary
cacheable_ranges_to_pdf_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
cacheable_ranges_to_pdf_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 99.96444819148688
cacheable_ranges_to_pdf_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP pdf_bandwidth_savings pdf_bandwidth_savings
# TYPE pdf_bandwidth_savings summary
pdf_bandwidth_savings{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_savings_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP pdf_bandwidth pdf_bandwidth
# TYPE pdf_bandwidth summary
pdf_bandwidth{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_bandwidth_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71504098
pdf_bandwidth_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
# HELP pdf_ranges_disk_size pdf_ranges_disk_size
# TYPE pdf_ranges_disk_size summary
pdf_ranges_disk_size{quantile="0.01",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.05",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.5",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.9",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.95",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.99",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size{quantile="0.999",path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 0
pdf_ranges_disk_size_sum{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 71478677
pdf_ranges_disk_size_count{path="",status_code="",method="",collection="",query="",app="clsi",host="16e825a531d1"} 1
```
</details>

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3871

#### Potential Impact

High.

#### Manual Testing Performed

- run small / large project through
- recompile lots of times, see no new ranges in metrics
- dark mode as shown in screenshots section
