### PR TITLE
handle compiles when shutting down

### DIFF
--- a/app.js
+++ b/app.js
@@ -255,6 +255,7 @@ if (Settings.processLifespanLimitMs) {
   setTimeout(() => {
     logger.log('shutting down, process is too old')
     Settings.processTooOld = true
+    enterMaintenanceMode()
   }, Settings.processLifespanLimitMs)
 }
 
@@ -359,6 +360,11 @@ loadHttpServer.post('/state/maint', function (req, res, next) {
   logger.info('getting message to set server to maint')
   return res.sendStatus(204)
 })
+
+function enterMaintenanceMode() {
+  STATE = 'maint'
+  logger.info('setting server to maint')
+}
 
 const port =
   __guard__(

--- a/app.js
+++ b/app.js
@@ -324,7 +324,7 @@ const loadHttpServer = express()
 
 loadHttpServer.post('/state/up', function (req, res, next) {
   STATE = 'up'
-  logger.info('getting message to set server to down')
+  logger.info('getting message to set server to up')
   return res.sendStatus(204)
 })
 


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

When the CLSI is shutting down we still accept compiles, we should reject them

#### Screenshots

NA

#### Related Issues / PRs



### Review

I still see a lot of compile errors during deploys, we ought to handle this case more gracefully.

We're not currently using the shutdown code with the `STATE` as far as I'm aware, but we should do that, or at least improve on this to get it all working

#### Potential Impact

Fewer compile errors during deploys?!?

#### Manual Testing Performed

- [X] Test in local dev environment

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Compile errors during deploys

#### Who Needs to Know?

NA