### PR TITLE
use fs.copyFile for performance

### DIFF
--- a/app/js/UrlCache.js
+++ b/app/js/UrlCache.js
@@ -19,7 +19,6 @@ const UrlFetcher = require('./UrlFetcher')
 const Settings = require('settings-sharelatex')
 const crypto = require('crypto')
 const fs = require('fs')
-const fse = require('fs-extra')
 const logger = require('logger-sharelatex')
 const async = require('async')
 
@@ -36,7 +35,7 @@ module.exports = UrlCache = {
         if (error != null) {
           return callback(error)
         }
-        return fse.copy(pathToCachedUrl, destPath, function (error) {
+        return fs.copyFile(pathToCachedUrl, destPath, function (error) {
           if (error != null) {
             logger.error(
               { err: error, from: pathToCachedUrl, to: destPath },

--- a/test/unit/js/UrlCacheTests.js
+++ b/test/unit/js/UrlCacheTests.js
@@ -27,7 +27,8 @@ describe('UrlCache', function () {
         'settings-sharelatex': (this.Settings = {
           path: { clsiCacheDir: '/cache/dir' }
         }),
-        fs: (this.fs = {})
+        fs: (this.fs = {}),
+        'fs-extra': (this.fse = { copy: sinon.stub().yields() })
       }
     }))
   })
@@ -268,7 +269,7 @@ describe('UrlCache', function () {
     })
 
     it('should copy the file to the new location', function () {
-      return this.UrlCache._copyFile
+      return this.fse.copy
         .calledWith(this.cachePath, this.destPath)
         .should.equal(true)
     })

--- a/test/unit/js/UrlCacheTests.js
+++ b/test/unit/js/UrlCacheTests.js
@@ -27,8 +27,7 @@ describe('UrlCache', function () {
         'settings-sharelatex': (this.Settings = {
           path: { clsiCacheDir: '/cache/dir' }
         }),
-        fs: (this.fs = {}),
-        'fs-extra': (this.fse = { copy: sinon.stub().yields() })
+        fs: (this.fs = { copyFile: sinon.stub().yields() })
       }
     }))
   })
@@ -249,7 +248,6 @@ describe('UrlCache', function () {
     beforeEach(function () {
       this.cachePath = 'path/to/cached/url'
       this.destPath = 'path/to/destination'
-      this.UrlCache._copyFile = sinon.stub().callsArg(2)
       this.UrlCache._ensureUrlIsInCache = sinon
         .stub()
         .callsArgWith(3, null, this.cachePath)
@@ -269,7 +267,7 @@ describe('UrlCache', function () {
     })
 
     it('should copy the file to the new location', function () {
-      return this.fse.copy
+      return this.fs.copyFile
         .calledWith(this.cachePath, this.destPath)
         .should.equal(true)
     })


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

The `fs-extra` module has a `copy` method which uses the native fs.copyFile method for performance. It's a useful module.

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

Performance improvement.

#### Potential Impact

Compiles

#### Manual Testing Performed

- [X] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald 