### PR TITLE
[perf] drop useless synchronous syscall on hot path for writing docs

### DIFF
--- a/app/js/ResourceWriter.js
+++ b/app/js/ResourceWriter.js
@@ -334,12 +334,7 @@ module.exports = ResourceWriter = {
             }
           ) // try and continue compiling even if http resource can not be downloaded at this time
         } else {
-          const process = require('process')
           fs.writeFile(path, resource.content, callback)
-          try {
-            let result
-            return (result = fs.lstatSync(path))
-          } catch (e) {}
         }
       })
     })


### PR DESCRIPTION
### Description

This PR is dropping a useless synchronous syscall on the hot path for writing docs to disk as part of a compile request.

#### Related Issues / PRs

No ticket, I noticed this while starting to port the service to Golang.

https://github.com/overleaf/clsi/pull/86 ( 3 years ago :see_no_evil: )

#### Potential Impact

Low.

#### Manual Testing Performed

- run unit/acceptance tests locally
