### PR TITLE
[ContentCacheManager] skip writing of duplicate streams

### DIFF
--- a/app/js/ContentCacheManager.js
+++ b/app/js/ContentCacheManager.js
@@ -20,13 +20,20 @@ async function update(contentDir, filePath) {
   const extractor = new PdfStreamsExtractor()
   const ranges = []
   const newRanges = []
+  const seenHashes = new Set()
   for await (const chunk of stream) {
     const pdfStreams = extractor.consume(chunk)
     for (const pdfStream of pdfStreams) {
       if (pdfStream.end - pdfStream.start < MIN_CHUNK_SIZE) continue
       const hash = pdfStreamHash(pdfStream.buffers)
+
       const range = { start: pdfStream.start, end: pdfStream.end, hash }
       ranges.push(range)
+
+      // Optimization: Skip writing of duplicate streams.
+      if (seenHashes.has(hash)) continue
+      seenHashes.add(hash)
+
       if (await writePdfStream(contentDir, hash, pdfStream.buffers)) {
         newRanges.push(range)
       }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3871
For https://github.com/overleaf/clsi/pull/235#issuecomment-842412183

This PR is adding a tracker for written hashes and skips writing for already written hashes. 

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3871
For https://github.com/overleaf/clsi/pull/235#issuecomment-842412183

#### Potential Impact

Low.

#### Manual Testing Performed

- Re-upload an image under a new name
- Add verbose logging, see diff below
- Compile with pdf caching
- See skipped duplicate

```
...
clsi_1                    | writing hash 8bcdc00b46e2821baa405bf18fb73e5b9fb743ae7f1d55c7dc9330c968ea2a52
clsi_1                    | writing hash 77debd1c216f91849fa11961ee13389405237d067b98e3b476f8a6864a36e5db
clsi_1                    | writing hash 7fb799a681f290cf0c943f2e95700702fb0c2f9680135a192e2b7b8690b16e90
clsi_1                    | writing hash 3e1ff9f1984936cf697b3b08943cb5aa7a8029ce34edff35ca17dcd217417763
clsi_1                    | writing hash ff2d76665075c16402c0a686e3d926efed87861c79d36d7f68da9904ddf3961c
clsi_1                    | writing hash e155cfbc12ea87128337a3bd3f21f7f14a15381ffaf00a1443340fd1f16d781d
clsi_1                    | writing hash 1601af6211e6d76d7bfa985c7b52447abdae873ec0c7c6a890eb9069900bf838
clsi_1                    | writing hash 4db7a2d2c767226061644b55abff4b83f3babf5f378c250b2f8bcc37e890a421
clsi_1                    | writing hash 4e2e293bbdf7f0941214533775bb5241496a0705dbb87f78d7d834e3578d11d7
clsi_1                    | writing hash 541512de64fb4ad18aaecb5aaf38da18715dcabb814391aa4439e1bf5aceae78
clsi_1                    | writing hash c6b44d23730085638e19d0fb6990a7f7935e8d6b94b09de62b8327b24a053a7c
clsi_1                    | writing hash 52226c5e59b27f4dd6ed0775afff9fb050d63b2587c4d99d7bceda4cecb6d82b
clsi_1                    | writing hash 57d712649361bf3b7f09525772698550ea98e5d6a47b4953fcd0df4c1d7c117b
clsi_1                    | duplicate hash 77debd1c216f91849fa11961ee13389405237d067b98e3b476f8a6864a36e5db
clsi_1                    | writing hash d7b155856476507c22c9505c6c0c6b94828a357284b5b9b86ffa378e259ccf9c
clsi_1                    | writing hash a1ea2fb288b017815bd209d9ece0336eff2a366afd0775eb6776aa1f390985e2
...
```

```diff
diff --git a/app/js/ContentCacheManager.js b/app/js/ContentCacheManager.js
index f631fa6..7e34e6f 100644
--- a/app/js/ContentCacheManager.js
+++ b/app/js/ContentCacheManager.js
@@ -31,7 +31,11 @@ async function update(contentDir, filePath) {
       ranges.push(range)
 
       // Optimization: Skip writing of duplicate streams.
-      if (seenHashes.has(hash)) continue
+      if (seenHashes.has(hash)) {
+        console.error('duplicate hash', hash)
+        continue
+      }
+      console.error('writing hash', hash)
       seenHashes.add(hash)
 
       if (await writePdfStream(contentDir, hash, pdfStream.buffers)) {
```
