### PR TITLE
LocalCommandRunner: fix unstoppable compilation

### DIFF
--- a/app/js/LocalCommandRunner.js
+++ b/app/js/LocalCommandRunner.js
@@ -55,7 +55,7 @@ module.exports = CommandRunner = {
     }
 
     // run command as detached process so it has its own process group (which can be killed if needed)
-    const proc = spawn(command[0], command.slice(1), { cwd: directory, env })
+    const proc = spawn(command[0], command.slice(1), { cwd: directory, env, detached: true })
 
     let stdout = ''
     proc.stdout.setEncoding('utf8').on('data', (data) => (stdout += data))


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
The options for `spawn` operation should contain a `detached` item to make the subprocess really detached, otherwise compilation will not be stoppable.


### Review



#### Potential Impact
N/A


#### Manual Testing Performed

- [x] Tested on my local docker overleaf

#### Accessibility
N/A


### Deployment
N/A


#### Deployment Checklist
N/A