### PR TITLE
[ProjectPersistenceManager] check all user content dirs for full disk

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,8 +412,9 @@ if (!module.parent) {
 module.exports = app
 
 setInterval(() => {
-  ProjectPersistenceManager.refreshExpiryTimeout()
-  ProjectPersistenceManager.clearExpiredProjects()
+  ProjectPersistenceManager.refreshExpiryTimeout(() => {
+    ProjectPersistenceManager.clearExpiredProjects()
+  })
 }, tenMinutes)
 
 function __guard__(value, transform) {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3871
For https://github.com/overleaf/issues/issues/4121

We are going to add more disks to the VMs and mount them to a non root path. This PR is extending the disk-full check to look at all the user content directories: compiles, output and file cache.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3871
For https://github.com/overleaf/issues/issues/4121

### Review

I included a bonus patch, adding a delay to the cleanup process to allow the disk-full check to complete first.

#### Potential Impact

Medium, disk filling up is bad.

#### Manual Testing Performed

- adjusted unit tests
