### PR TITLE
[perf] UrlCache: pure fs based cache state for downloads

### DIFF
--- a/app/js/ResourceWriter.js
+++ b/app/js/ResourceWriter.js
@@ -76,12 +76,16 @@ module.exports = ResourceWriter = {
           )
         }
       )
-    } else {
-      logger.log(
-        { project_id: request.project_id, user_id: request.user_id },
-        'full sync'
-      )
-      return this.saveAllResourcesToDisk(
+    }
+    logger.log(
+      { project_id: request.project_id, user_id: request.user_id },
+      'full sync'
+    )
+    UrlCache.createProjectDir(request.project_id, (error) => {
+      if (error != null) {
+        return callback(error)
+      }
+      this.saveAllResourcesToDisk(
         request.project_id,
         request.resources,
         basePath,
@@ -102,7 +106,7 @@ module.exports = ResourceWriter = {
           )
         }
       )
-    }
+    })
   },
 
   saveIncrementalResourcesToDisk(project_id, resources, basePath, callback) {

--- a/app/js/UrlCache.js
+++ b/app/js/UrlCache.js
@@ -12,247 +12,54 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-let UrlCache
-const db = require('./db')
-const dbQueue = require('./DbQueue')
 const UrlFetcher = require('./UrlFetcher')
 const Settings = require('settings-sharelatex')
-const crypto = require('crypto')
 const fs = require('fs')
-const logger = require('logger-sharelatex')
-const async = require('async')
+const fse = require('fs-extra')
+const Path = require('path')
+const { callbackify } = require('util')
 
-module.exports = UrlCache = {
-  downloadUrlToFile(project_id, url, destPath, lastModified, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
-    return UrlCache._ensureUrlIsInCache(
-      project_id,
-      url,
-      lastModified,
-      (error, pathToCachedUrl) => {
-        if (error != null) {
-          return callback(error)
-        }
-        return fs.copyFile(pathToCachedUrl, destPath, function (error) {
-          if (error != null) {
-            logger.error(
-              { err: error, from: pathToCachedUrl, to: destPath },
-              'error copying file from cache'
-            )
-            return UrlCache._clearUrlDetails(project_id, url, () =>
-              callback(error)
-            )
-          } else {
-            return callback(error)
-          }
-        })
-      }
-    )
-  },
+function getProjectDir(projectId) {
+  return Path.join(Settings.path.clsiCacheDir, projectId)
+}
 
-  clearProject(project_id, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
-    return UrlCache._findAllUrlsInProject(project_id, function (error, urls) {
-      logger.log(
-        { project_id, url_count: urls.length },
-        'clearing project URLs'
-      )
-      if (error != null) {
-        return callback(error)
-      }
-      const jobs = Array.from(urls || []).map((url) =>
-        ((url) => (callback) =>
-          UrlCache._clearUrlFromCache(project_id, url, function (error) {
-            if (error != null) {
-              logger.error(
-                { err: error, project_id, url },
-                'error clearing project URL'
-              )
-            }
-            return callback()
-          }))(url)
-      )
-      return async.series(jobs, callback)
-    })
-  },
+function getCachePath(projectId, url, lastModified) {
+  // The url is a filestore URL.
+  // It is sufficient to look at the path and mtime for uniqueness.
+  const mtime = (lastModified && lastModified.getTime()) || 0
+  const key = new URL(url).pathname.replace(/\//g, '-') + '-' + mtime
+  return Path.join(getProjectDir(projectId), key)
+}
 
-  _ensureUrlIsInCache(project_id, url, lastModified, callback) {
-    if (callback == null) {
-      callback = function (error, pathOnDisk) {}
-    }
-    if (lastModified != null) {
-      // MYSQL only stores dates to an accuracy of a second but the incoming lastModified might have milliseconds.
-      // So round down to seconds
-      lastModified = new Date(Math.floor(lastModified.getTime() / 1000) * 1000)
-    }
-    return UrlCache._doesUrlNeedDownloading(
-      project_id,
-      url,
-      lastModified,
-      (error, needsDownloading) => {
-        if (error != null) {
-          return callback(error)
-        }
-        if (needsDownloading) {
-          logger.log({ url, lastModified }, 'downloading URL')
-          return UrlFetcher.pipeUrlToFileWithRetry(
-            url,
-            UrlCache._cacheFilePathForUrl(project_id, url),
-            (error) => {
-              if (error != null) {
-                return callback(error)
-              }
-              return UrlCache._updateOrCreateUrlDetails(
-                project_id,
-                url,
-                lastModified,
-                (error) => {
-                  if (error != null) {
-                    return callback(error)
-                  }
-                  return callback(
-                    null,
-                    UrlCache._cacheFilePathForUrl(project_id, url)
-                  )
-                }
-              )
-            }
-          )
-        } else {
-          logger.log({ url, lastModified }, 'URL is up to date in cache')
-          return callback(null, UrlCache._cacheFilePathForUrl(project_id, url))
-        }
-      }
-    )
-  },
+async function clearProject(projectId) {
+  await fse.remove(getProjectDir(projectId))
+}
 
-  _doesUrlNeedDownloading(project_id, url, lastModified, callback) {
-    if (callback == null) {
-      callback = function (error, needsDownloading) {}
-    }
-    if (lastModified == null) {
-      return callback(null, true)
-    }
-    return UrlCache._findUrlDetails(project_id, url, function (
-      error,
-      urlDetails
-    ) {
-      if (error != null) {
-        return callback(error)
-      }
-      if (
-        urlDetails == null ||
-        urlDetails.lastModified == null ||
-        urlDetails.lastModified.getTime() < lastModified.getTime()
-      ) {
-        return callback(null, true)
-      } else {
-        return callback(null, false)
-      }
-    })
-  },
+async function createProjectDir(projectId) {
+  await fs.promises.mkdir(getProjectDir(projectId), { recursive: true })
+}
 
-  _cacheFileNameForUrl(project_id, url) {
-    return project_id + ':' + crypto.createHash('md5').update(url).digest('hex')
-  },
-
-  _cacheFilePathForUrl(project_id, url) {
-    return `${Settings.path.clsiCacheDir}/${UrlCache._cacheFileNameForUrl(
-      project_id,
-      url
-    )}`
-  },
-
-  _clearUrlFromCache(project_id, url, callback) {
-    if (callback == null) {
-      callback = function (error) {}
+async function downloadUrlToFile(projectId, url, destPath, lastModified) {
+  const cachePath = getCachePath(projectId, url, lastModified)
+  try {
+    await fs.promises.copyFile(cachePath, destPath)
+    return
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      throw e
     }
-    return UrlCache._clearUrlDetails(project_id, url, function (error) {
-      if (error != null) {
-        return callback(error)
-      }
-      return UrlCache._deleteUrlCacheFromDisk(project_id, url, function (
-        error
-      ) {
-        if (error != null) {
-          return callback(error)
-        }
-        return callback(null)
-      })
-    })
-  },
+  }
+  await UrlFetcher.promises.pipeUrlToFileWithRetry(url, cachePath)
+  await fs.promises.copyFile(cachePath, destPath)
+}
 
-  _deleteUrlCacheFromDisk(project_id, url, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
-    return fs.unlink(UrlCache._cacheFilePathForUrl(project_id, url), function (
-      error
-    ) {
-      if (error != null && error.code !== 'ENOENT') {
-        // no error if the file isn't present
-        return callback(error)
-      } else {
-        return callback()
-      }
-    })
-  },
-
-  _findUrlDetails(project_id, url, callback) {
-    if (callback == null) {
-      callback = function (error, urlDetails) {}
-    }
-    const job = (cb) =>
-      db.UrlCache.findOne({ where: { url, project_id } })
-        .then((urlDetails) => cb(null, urlDetails))
-        .error(cb)
-    return dbQueue.queue.push(job, callback)
-  },
-
-  _updateOrCreateUrlDetails(project_id, url, lastModified, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
-    const job = (cb) =>
-      db.UrlCache.findOrCreate({ where: { url, project_id } })
-        .spread((urlDetails, created) =>
-          urlDetails
-            .update({ lastModified })
-            .then(() => cb())
-            .error(cb)
-        )
-        .error(cb)
-    return dbQueue.queue.push(job, callback)
-  },
-
-  _clearUrlDetails(project_id, url, callback) {
-    if (callback == null) {
-      callback = function (error) {}
-    }
-    const job = (cb) =>
-      db.UrlCache.destroy({ where: { url, project_id } })
-        .then(() => cb(null))
-        .error(cb)
-    return dbQueue.queue.push(job, callback)
-  },
-
-  _findAllUrlsInProject(project_id, callback) {
-    if (callback == null) {
-      callback = function (error, urls) {}
-    }
-    const job = (cb) =>
-      db.UrlCache.findAll({ where: { project_id } })
-        .then((urlEntries) =>
-          cb(
-            null,
-            urlEntries.map((entry) => entry.url)
-          )
-        )
-        .error(cb)
-    return dbQueue.queue.push(job, callback)
+module.exports = {
+  clearProject: callbackify(clearProject),
+  createProjectDir: callbackify(createProjectDir),
+  downloadUrlToFile: callbackify(downloadUrlToFile),
+  promises: {
+    clearProject,
+    createProjectDir,
+    downloadUrlToFile
   }
 }

--- a/app/js/UrlCache.js
+++ b/app/js/UrlCache.js
@@ -21,7 +21,6 @@ const crypto = require('crypto')
 const fs = require('fs')
 const logger = require('logger-sharelatex')
 const async = require('async')
-const Metrics = require('./Metrics')
 
 module.exports = UrlCache = {
   downloadUrlToFile(project_id, url, destPath, lastModified, callback) {
@@ -207,22 +206,17 @@ module.exports = UrlCache = {
     if (callback == null) {
       callback = function (error, urlDetails) {}
     }
-    const timer = new Metrics.Timer('db-find-url-details')
     const job = (cb) =>
       db.UrlCache.findOne({ where: { url, project_id } })
         .then((urlDetails) => cb(null, urlDetails))
         .error(cb)
-    dbQueue.queue.push(job, (error, urlDetails) => {
-      timer.done()
-      callback(error, urlDetails)
-    })
+    return dbQueue.queue.push(job, callback)
   },
 
   _updateOrCreateUrlDetails(project_id, url, lastModified, callback) {
     if (callback == null) {
       callback = function (error) {}
     }
-    const timer = new Metrics.Timer('db-update-or-create-url-details')
     const job = (cb) =>
       db.UrlCache.findOrCreate({ where: { url, project_id } })
         .spread((urlDetails, created) =>
@@ -232,32 +226,24 @@ module.exports = UrlCache = {
             .error(cb)
         )
         .error(cb)
-    dbQueue.queue.push(job, (error) => {
-      timer.done()
-      callback(error)
-    })
+    return dbQueue.queue.push(job, callback)
   },
 
   _clearUrlDetails(project_id, url, callback) {
     if (callback == null) {
       callback = function (error) {}
     }
-    const timer = new Metrics.Timer('db-clear-url-details')
     const job = (cb) =>
       db.UrlCache.destroy({ where: { url, project_id } })
         .then(() => cb(null))
         .error(cb)
-    dbQueue.queue.push(job, (error) => {
-      timer.done()
-      callback(error)
-    })
+    return dbQueue.queue.push(job, callback)
   },
 
   _findAllUrlsInProject(project_id, callback) {
     if (callback == null) {
       callback = function (error, urls) {}
     }
-    const timer = new Metrics.Timer('db-find-urls-in-project')
     const job = (cb) =>
       db.UrlCache.findAll({ where: { project_id } })
         .then((urlEntries) =>
@@ -267,9 +253,6 @@ module.exports = UrlCache = {
           )
         )
         .error(cb)
-    dbQueue.queue.push(job, (err, urls) => {
-      timer.done()
-      callback(err, urls)
-    })
+    return dbQueue.queue.push(job, callback)
   }
 }

--- a/app/js/UrlFetcher.js
+++ b/app/js/UrlFetcher.js
@@ -19,6 +19,7 @@ const logger = require('logger-sharelatex')
 const settings = require('settings-sharelatex')
 const URL = require('url')
 const async = require('async')
+const { promisify } = require('util')
 
 const oneMinute = 60 * 1000
 
@@ -132,4 +133,8 @@ module.exports = UrlFetcher = {
       }
     })
   }
+}
+
+module.exports.promises = {
+  pipeUrlToFileWithRetry: promisify(UrlFetcher.pipeUrlToFileWithRetry)
 }

--- a/test/acceptance/js/UrlCachingTests.js
+++ b/test/acceptance/js/UrlCachingTests.js
@@ -250,8 +250,8 @@ describe('Url Caching', function () {
       return Server.getFile.restore()
     })
 
-    return it('should not download the image again', function () {
-      return Server.getFile.called.should.equal(false)
+    return it('should download the other revision', function () {
+      return Server.getFile.called.should.equal(true)
     })
   })
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -15,5 +15,5 @@ SandboxedModule.configure({
       err() {}
     }
   },
-  globals: { Buffer, console, process }
+  globals: { Buffer, console, process, URL }
 })

--- a/test/unit/js/ResourceWriterTests.js
+++ b/test/unit/js/ResourceWriterTests.js
@@ -31,7 +31,9 @@ describe('ResourceWriter', function () {
         }),
         './ResourceStateManager': (this.ResourceStateManager = {}),
         wrench: (this.wrench = {}),
-        './UrlCache': (this.UrlCache = {}),
+        './UrlCache': (this.UrlCache = {
+          createProjectDir: sinon.stub().yields()
+        }),
         './OutputFileFinder': (this.OutputFileFinder = {}),
         './Metrics': (this.Metrics = {
           inc: sinon.stub(),

--- a/test/unit/js/UrlCacheTests.js
+++ b/test/unit/js/UrlCacheTests.js
@@ -12,342 +12,101 @@
  */
 const SandboxedModule = require('sandboxed-module')
 const sinon = require('sinon')
+const { expect } = require('chai')
 const modulePath = require('path').join(__dirname, '../../../app/js/UrlCache')
-const { EventEmitter } = require('events')
 
 describe('UrlCache', function () {
   beforeEach(function () {
     this.callback = sinon.stub()
-    this.url = 'www.example.com/file'
-    this.project_id = 'project-id-123'
+    this.url =
+      'http://filestore/project/60b0dd39c418bc00598a0d22/file/60ae721ffb1d920027d3201f'
+    this.project_id = '60b0dd39c418bc00598a0d22'
     return (this.UrlCache = SandboxedModule.require(modulePath, {
       requires: {
-        './db': {},
-        './UrlFetcher': (this.UrlFetcher = {}),
+        './UrlFetcher': (this.UrlFetcher = {
+          promises: { pipeUrlToFileWithRetry: sinon.stub().resolves() }
+        }),
         'settings-sharelatex': (this.Settings = {
           path: { clsiCacheDir: '/cache/dir' }
         }),
-        fs: (this.fs = { copyFile: sinon.stub().yields() })
+        'fs-extra': (this.fse = { remove: sinon.stub().resolves() }),
+        fs: (this.fs = {
+          promises: {
+            copyFile: sinon.stub().resolves()
+          }
+        })
       }
     }))
   })
 
-  describe('_doesUrlNeedDownloading', function () {
-    beforeEach(function () {
-      this.lastModified = new Date()
-      return (this.lastModifiedRoundedToSeconds = new Date(
-        Math.floor(this.lastModified.getTime() / 1000) * 1000
-      ))
-    })
-
-    describe('when URL does not exist in cache', function () {
-      beforeEach(function () {
-        this.UrlCache._findUrlDetails = sinon.stub().callsArgWith(2, null, null)
-        return this.UrlCache._doesUrlNeedDownloading(
-          this.project_id,
-          this.url,
-          this.lastModified,
-          this.callback
-        )
-      })
-
-      return it('should return the callback with true', function () {
-        return this.callback.calledWith(null, true).should.equal(true)
-      })
-    })
-
-    return describe('when URL does exist in cache', function () {
-      beforeEach(function () {
-        this.urlDetails = {}
-        return (this.UrlCache._findUrlDetails = sinon
-          .stub()
-          .callsArgWith(2, null, this.urlDetails))
-      })
-
-      describe('when the modified date is more recent than the cached modified date', function () {
-        beforeEach(function () {
-          this.urlDetails.lastModified = new Date(
-            this.lastModified.getTime() - 1000
-          )
-          return this.UrlCache._doesUrlNeedDownloading(
-            this.project_id,
-            this.url,
-            this.lastModified,
-            this.callback
-          )
-        })
-
-        it('should get the url details', function () {
-          return this.UrlCache._findUrlDetails
-            .calledWith(this.project_id, this.url)
-            .should.equal(true)
-        })
-
-        return it('should return the callback with true', function () {
-          return this.callback.calledWith(null, true).should.equal(true)
-        })
-      })
-
-      describe('when the cached modified date is more recent than the modified date', function () {
-        beforeEach(function () {
-          this.urlDetails.lastModified = new Date(
-            this.lastModified.getTime() + 1000
-          )
-          return this.UrlCache._doesUrlNeedDownloading(
-            this.project_id,
-            this.url,
-            this.lastModified,
-            this.callback
-          )
-        })
-
-        return it('should return the callback with false', function () {
-          return this.callback.calledWith(null, false).should.equal(true)
-        })
-      })
-
-      describe('when the cached modified date is equal to the modified date', function () {
-        beforeEach(function () {
-          this.urlDetails.lastModified = this.lastModified
-          return this.UrlCache._doesUrlNeedDownloading(
-            this.project_id,
-            this.url,
-            this.lastModified,
-            this.callback
-          )
-        })
-
-        return it('should return the callback with false', function () {
-          return this.callback.calledWith(null, false).should.equal(true)
-        })
-      })
-
-      describe('when the provided modified date does not exist', function () {
-        beforeEach(function () {
-          this.lastModified = null
-          return this.UrlCache._doesUrlNeedDownloading(
-            this.project_id,
-            this.url,
-            this.lastModified,
-            this.callback
-          )
-        })
-
-        return it('should return the callback with true', function () {
-          return this.callback.calledWith(null, true).should.equal(true)
-        })
-      })
-
-      return describe('when the URL does not have a modified date', function () {
-        beforeEach(function () {
-          this.urlDetails.lastModified = null
-          return this.UrlCache._doesUrlNeedDownloading(
-            this.project_id,
-            this.url,
-            this.lastModified,
-            this.callback
-          )
-        })
-
-        return it('should return the callback with true', function () {
-          return this.callback.calledWith(null, true).should.equal(true)
-        })
-      })
-    })
-  })
-
-  describe('_ensureUrlIsInCache', function () {
-    beforeEach(function () {
-      this.UrlFetcher.pipeUrlToFileWithRetry = sinon.stub().callsArg(2)
-      return (this.UrlCache._updateOrCreateUrlDetails = sinon
-        .stub()
-        .callsArg(3))
-    })
-
-    describe('when the URL needs updating', function () {
-      beforeEach(function () {
-        this.UrlCache._doesUrlNeedDownloading = sinon
-          .stub()
-          .callsArgWith(3, null, true)
-        return this.UrlCache._ensureUrlIsInCache(
-          this.project_id,
-          this.url,
-          this.lastModified,
-          this.callback
-        )
-      })
-
-      it('should check that the url needs downloading', function () {
-        return this.UrlCache._doesUrlNeedDownloading
-          .calledWith(
-            this.project_id,
-            this.url,
-            this.lastModifiedRoundedToSeconds
-          )
-          .should.equal(true)
-      })
-
-      it('should download the URL to the cache file', function () {
-        return this.UrlFetcher.pipeUrlToFileWithRetry
-          .calledWith(
-            this.url,
-            this.UrlCache._cacheFilePathForUrl(this.project_id, this.url)
-          )
-          .should.equal(true)
-      })
-
-      it('should update the database entry', function () {
-        return this.UrlCache._updateOrCreateUrlDetails
-          .calledWith(
-            this.project_id,
-            this.url,
-            this.lastModifiedRoundedToSeconds
-          )
-          .should.equal(true)
-      })
-
-      return it('should return the callback with the cache file path', function () {
-        return this.callback
-          .calledWith(
-            null,
-            this.UrlCache._cacheFilePathForUrl(this.project_id, this.url)
-          )
-          .should.equal(true)
-      })
-    })
-
-    return describe('when the URL does not need updating', function () {
-      beforeEach(function () {
-        this.UrlCache._doesUrlNeedDownloading = sinon
-          .stub()
-          .callsArgWith(3, null, false)
-        return this.UrlCache._ensureUrlIsInCache(
-          this.project_id,
-          this.url,
-          this.lastModified,
-          this.callback
-        )
-      })
-
-      it('should not download the URL to the cache file', function () {
-        return this.UrlFetcher.pipeUrlToFileWithRetry.called.should.equal(false)
-      })
-
-      return it('should return the callback with the cache file path', function () {
-        return this.callback
-          .calledWith(
-            null,
-            this.UrlCache._cacheFilePathForUrl(this.project_id, this.url)
-          )
-          .should.equal(true)
-      })
-    })
-  })
-
   describe('downloadUrlToFile', function () {
     beforeEach(function () {
-      this.cachePath = 'path/to/cached/url'
       this.destPath = 'path/to/destination'
-      this.UrlCache._ensureUrlIsInCache = sinon
-        .stub()
-        .callsArgWith(3, null, this.cachePath)
-      return this.UrlCache.downloadUrlToFile(
+    })
+
+    it('should not download on the happy path', function (done) {
+      this.UrlCache.downloadUrlToFile(
         this.project_id,
         this.url,
         this.destPath,
         this.lastModified,
-        this.callback
+        (error) => {
+          expect(error).to.not.exist
+          expect(
+            this.UrlFetcher.promises.pipeUrlToFileWithRetry.called
+          ).to.equal(false)
+          done()
+        }
       )
     })
 
-    it('should ensure the URL is downloaded and updated in the cache', function () {
-      return this.UrlCache._ensureUrlIsInCache
-        .calledWith(this.project_id, this.url, this.lastModified)
-        .should.equal(true)
-    })
+    it('should download on cache miss', function (done) {
+      const codedError = new Error()
+      codedError.code = 'ENOENT'
+      this.fs.promises.copyFile.onCall(0).rejects(codedError)
+      this.fs.promises.copyFile.onCall(1).resolves()
 
-    it('should copy the file to the new location', function () {
-      return this.fs.copyFile
-        .calledWith(this.cachePath, this.destPath)
-        .should.equal(true)
-    })
-
-    return it('should call the callback', function () {
-      return this.callback.called.should.equal(true)
-    })
-  })
-
-  describe('_deleteUrlCacheFromDisk', function () {
-    beforeEach(function () {
-      this.fs.unlink = sinon.stub().callsArg(1)
-      return this.UrlCache._deleteUrlCacheFromDisk(
+      this.UrlCache.downloadUrlToFile(
         this.project_id,
         this.url,
-        this.callback
+        this.destPath,
+        this.lastModified,
+        (error) => {
+          expect(error).to.not.exist
+          expect(
+            this.UrlFetcher.promises.pipeUrlToFileWithRetry.called
+          ).to.equal(true)
+          done()
+        }
       )
     })
 
-    it('should delete the cache file', function () {
-      return this.fs.unlink
-        .calledWith(
-          this.UrlCache._cacheFilePathForUrl(this.project_id, this.url)
-        )
-        .should.equal(true)
-    })
-
-    return it('should call the callback', function () {
-      return this.callback.called.should.equal(true)
-    })
-  })
-
-  describe('_clearUrlFromCache', function () {
-    beforeEach(function () {
-      this.UrlCache._deleteUrlCacheFromDisk = sinon.stub().callsArg(2)
-      this.UrlCache._clearUrlDetails = sinon.stub().callsArg(2)
-      return this.UrlCache._clearUrlFromCache(
+    it('should raise non cache-miss errors', function (done) {
+      const codedError = new Error()
+      codedError.code = 'FOO'
+      this.fs.promises.copyFile.rejects(codedError)
+      this.UrlCache.downloadUrlToFile(
         this.project_id,
         this.url,
-        this.callback
+        this.destPath,
+        this.lastModified,
+        (error) => {
+          expect(error).to.equal(codedError)
+          done()
+        }
       )
-    })
-
-    it('should delete the file on disk', function () {
-      return this.UrlCache._deleteUrlCacheFromDisk
-        .calledWith(this.project_id, this.url)
-        .should.equal(true)
-    })
-
-    it('should clear the entry in the database', function () {
-      return this.UrlCache._clearUrlDetails
-        .calledWith(this.project_id, this.url)
-        .should.equal(true)
-    })
-
-    return it('should call the callback', function () {
-      return this.callback.called.should.equal(true)
     })
   })
 
-  return describe('clearProject', function () {
-    beforeEach(function () {
-      this.urls = ['www.example.com/file1', 'www.example.com/file2']
-      this.UrlCache._findAllUrlsInProject = sinon
-        .stub()
-        .callsArgWith(1, null, this.urls)
-      this.UrlCache._clearUrlFromCache = sinon.stub().callsArg(2)
-      return this.UrlCache.clearProject(this.project_id, this.callback)
+  describe('clearProject', function () {
+    beforeEach(function (done) {
+      this.UrlCache.clearProject(this.project_id, done)
     })
 
-    it('should clear the cache for each url in the project', function () {
-      return Array.from(this.urls).map((url) =>
-        this.UrlCache._clearUrlFromCache
-          .calledWith(this.project_id, url)
-          .should.equal(true)
-      )
-    })
-
-    return it('should call the callback', function () {
-      return this.callback.called.should.equal(true)
+    it('should clear the cache in bulk', function () {
+      expect(
+        this.fse.remove.calledWith('/cache/dir/' + this.project_id)
+      ).to.equal(true)
     })
   })
 })

--- a/test/unit/js/UrlFetcherTests.js
+++ b/test/unit/js/UrlFetcherTests.js
@@ -23,7 +23,10 @@ describe('UrlFetcher', function () {
         request: {
           defaults: (this.defaults = sinon.stub().returns((this.request = {})))
         },
-        fs: (this.fs = {}),
+        fs: (this.fs = {
+          rename: sinon.stub().yields(),
+          unlink: sinon.stub().yields()
+        }),
         'settings-sharelatex': (this.settings = {})
       }
     }))
@@ -143,9 +146,15 @@ describe('UrlFetcher', function () {
             .should.equal(true)
         })
 
-        it('should open the file for writing', function () {
+        it('should open the atomic file for writing', function () {
           return this.fs.createWriteStream
-            .calledWith(this.path)
+            .calledWith(this.path + '~')
+            .should.equal(true)
+        })
+
+        it('should move the atomic file to the target', function () {
+          return this.fs.rename
+            .calledWith(this.path + '~', this.path)
             .should.equal(true)
         })
 


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4454
For https://github.com/overleaf/issues/issues/3871

This PR is reworking the state-tracking for the URL cache to pure fs based state.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4454
For https://github.com/overleaf/issues/issues/3871

### Review

The happy path for writing a file resource is one copyFile sys call now. On cache miss the file will get downloaded.
The download process writes the response atomically using a temp file, in order to not populate the target file until after the response has been written in full. This could otherwise lead to false-positive cache hits on broken downloads.

The keys in the cache are now partitioned by projectId in a folder. The filenames are based on the filestore URL and mtime. This is dropping the overhead of expensive, synchronous hashing of the URL.

Clearing the cache for a project drops all of the files in the project directory in bulk.

I had to change one acceptance test for not downloading a file if it's mtime went backwards. I am always downloading a file in case of a cache miss, and I am not looking at already existing entries by URL with non matching mtime. Is there a particular user story for the old logic?

#### Potential Impact

High. No binary files for compiles.

#### Manual Testing Performed

- run acceptance tests (covers binary file download)
- delete cache and compile dir in dev-env
- compile project with many images
- use clear cache feature in editor, see cleared dirs in dev-env
