### PR TITLE
[perf] store the last access time of a project in memory

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ const OutputCacheManager = require('./app/js/OutputCacheManager')
 const ContentCacheManager = require('./app/js/ContentCacheManager')
 
 require('./app/js/db').sync()
+ProjectPersistenceManager.init()
 
 const express = require('express')
 const bodyParser = require('body-parser')

--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-const tenMinutes = 10 * 60 * 1000
 const Metrics = require('@overleaf/metrics')
 Metrics.initialize('clsi')
 
@@ -411,12 +410,6 @@ if (!module.parent) {
 }
 
 module.exports = app
-
-setInterval(() => {
-  ProjectPersistenceManager.refreshExpiryTimeout(() => {
-    ProjectPersistenceManager.clearExpiredProjects()
-  })
-}, tenMinutes)
 
 function __guard__(value, transform) {
   return typeof value !== 'undefined' && value !== null

--- a/app/js/ProjectPersistenceManager.js
+++ b/app/js/ProjectPersistenceManager.js
@@ -12,7 +12,6 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
 let ProjectPersistenceManager
-const Metrics = require('./Metrics')
 const UrlCache = require('./UrlCache')
 const CompileManager = require('./CompileManager')
 const db = require('./db')
@@ -65,7 +64,6 @@ module.exports = ProjectPersistenceManager = {
     if (callback == null) {
       callback = function (error) {}
     }
-    const timer = new Metrics.Timer('db-bump-last-accessed')
     const job = (cb) =>
       db.Project.findOrCreate({ where: { project_id } })
         .spread((project, created) =>
@@ -75,10 +73,7 @@ module.exports = ProjectPersistenceManager = {
             .error(cb)
         )
         .error(cb)
-    dbQueue.queue.push(job, (error) => {
-      timer.done()
-      callback(error)
-    })
+    return dbQueue.queue.push(job, callback)
   },
 
   clearExpiredProjects(callback) {

--- a/app/js/ProjectPersistenceManager.js
+++ b/app/js/ProjectPersistenceManager.js
@@ -65,19 +65,19 @@ module.exports = ProjectPersistenceManager = {
   refreshExpiryTimeout: callbackify(refreshExpiryTimeout),
 
   init() {
-    fs.readdir(Settings.path.compilesDir, (err, projectIds) => {
+    fs.readdir(Settings.path.compilesDir, (err, dirs) => {
       if (err) {
         logger.warn({ err }, 'cannot get project listing')
         return
       }
 
-      async.eachLimit(projectIds, 50, (projectId, cb) => {
-        const outputPdf = Path.join(
+      async.eachLimit(dirs, 50, (projectAndUserId, cb) => {
+        const compileDir = Path.join(
           Settings.path.compilesDir,
-          projectId,
-          'output.pdf'
+          projectAndUserId
         )
-        fs.stat(outputPdf, (err, stats) => {
+        const projectId = projectAndUserId.slice(0, 24)
+        fs.stat(compileDir, (err, stats) => {
           if (err) {
             // Schedule for immediate cleanup
             LAST_ACCESS.set(projectId, 0)


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4454
For https://github.com/overleaf/issues/issues/3871

This PR is changing the state tracking for last access time on a project from sqlite to an in-memory Map.

#### Related Issues / PRs


For https://github.com/overleaf/issues/issues/4454
For https://github.com/overleaf/issues/issues/3871

### Review

The Map will get populated on clsi startup, using the mtime of the output.pdf for the last access time.

See https://digital-science.slack.com/archives/C0216GDEG9L/p1623668763010200 for estimates on the Map size.

#### Potential Impact

Medium. Disk fill up.

#### Manual Testing Performed

- compile a few projects
- add log line for map contents
- restart clsi
- see entries for old projects
