### PR TITLE
very basic mvp for shedding load

### DIFF
--- a/app.js
+++ b/app.js
@@ -331,7 +331,7 @@ const loadTcpServer = net.createServer(function (socket) {
     const freeLoad = availableWorkingCpus - currentLoad
     let freeLoadPercentage = Math.round((freeLoad / availableWorkingCpus) * 100)
     if (freeLoadPercentage <= 0) {
-      freeLoadPercentage = 1 // when its 0 the server is set to drain and will move projects to different servers
+      freeLoadPercentage = 0 // when its 0 the server is set to drain and will move projects to different servers
     }
     socket.write(`up, ${freeLoadPercentage}%\n`, 'ASCII')
     return socket.end()


### PR DESCRIPTION


<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description
I decided to try and keep load shedding as simple as possible for the first attempt. This is the simplest possible implementation I think we can do and should prove a useful test. We can initially deploy it to 1 instance group and watch how it behaves over a few days. 

The change made is when the box is over 100% capacity start to shed load.

If this proves successful we can then roll it out to more instance groups and possibly make shedding more aggressive (targeting ~90% cpu usage etc)


#### Related Issues / PRs
https://github.com/overleaf/issues/issues/4137


### Review



#### Potential Impact
- Medium, projects could stampeded all over our clsi's if we shed too much



### Deployment

- [ ] rake deploy:clsi[staging,master,latest]
- [ ] only deploy to 1 instance group and then cancel the deploy for a while

#### Metrics and Monitoring
https://console.cloud.google.com/monitoring/dashboards/builder/6376263191972157537?authuser=1&project=mgcp-1117973-ol-prod&dashboardBuilderState=%257B%2522editModeEnabled%2522:false%257D&timeDomain=1h


#### Who Needs to Know?
@emcsween @briangough @das7pad 