### PR TITLE
[CompileController] emit status=failure for an empty output.pdf file

### DIFF
--- a/app/js/CompileController.js
+++ b/app/js/CompileController.js
@@ -88,7 +88,7 @@ module.exports = CompileController = {
               let file
               status = 'failure'
               for (file of Array.from(outputFiles)) {
-                if (file.path === 'output.pdf') {
+                if (file.path === 'output.pdf' && file.size > 0) {
                   status = 'success'
                 }
               }

--- a/app/js/CompileController.js
+++ b/app/js/CompileController.js
@@ -123,7 +123,7 @@ module.exports = CompileController = {
                 stats,
                 timings,
                 outputFiles: outputFiles.map((file) => {
-                  const record = {
+                  return {
                     url:
                       `${Settings.apis.clsi.url}/project/${request.project_id}` +
                       (request.user_id != null
@@ -131,18 +131,8 @@ module.exports = CompileController = {
                         : '') +
                       (file.build != null ? `/build/${file.build}` : '') +
                       `/output/${file.path}`,
-                    path: file.path,
-                    type: file.type,
-                    build: file.build,
-                    contentId: file.contentId
+                    ...file
                   }
-                  if (file.ranges != null) {
-                    record.ranges = file.ranges
-                  }
-                  if (file.size != null) {
-                    record.size = file.size
-                  }
-                  return record
                 })
               }
             })

--- a/test/unit/js/CompileControllerTests.js
+++ b/test/unit/js/CompileControllerTests.js
@@ -157,11 +157,7 @@ describe('CompileController', function () {
               outputFiles: this.output_files.map((file) => {
                 return {
                   url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
-                  path: file.path,
-                  type: file.type,
-                  build: file.build,
-                  // gets dropped by JSON.stringify
-                  contentId: undefined
+                  ...file
                 }
               })
             }
@@ -202,11 +198,7 @@ describe('CompileController', function () {
               outputFiles: this.output_files.map((file) => {
                 return {
                   url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
-                  path: file.path,
-                  type: file.type,
-                  build: file.build,
-                  // gets dropped by JSON.stringify
-                  contentId: undefined
+                  ...file
                 }
               })
             }

--- a/test/unit/js/CompileControllerTests.js
+++ b/test/unit/js/CompileControllerTests.js
@@ -99,6 +99,7 @@ describe('CompileController', function () {
         {
           path: 'output.pdf',
           type: 'pdf',
+          size: 1337,
           build: 1234
         },
         {
@@ -172,6 +173,48 @@ describe('CompileController', function () {
           {
             path: 'fake_output.pdf',
             type: 'pdf',
+            build: 1234
+          },
+          {
+            path: 'output.log',
+            type: 'log',
+            build: 1234
+          }
+        ]
+        this.CompileManager.doCompileWithLock = sinon
+          .stub()
+          .yields(null, this.output_files, this.stats, this.timings)
+        this.CompileController.compile(this.req, this.res)
+      })
+
+      it('should return the JSON response with status failure', function () {
+        this.res.status.calledWith(200).should.equal(true)
+        this.res.send
+          .calledWith({
+            compile: {
+              status: 'failure',
+              error: null,
+              stats: this.stats,
+              timings: this.timings,
+              outputFiles: this.output_files.map((file) => {
+                return {
+                  url: `${this.Settings.apis.clsi.url}/project/${this.project_id}/build/${file.build}/output/${file.path}`,
+                  ...file
+                }
+              })
+            }
+          })
+          .should.equal(true)
+      })
+    })
+
+    describe('with an empty output.pdf', function () {
+      beforeEach(function () {
+        this.output_files = [
+          {
+            path: 'output.pdf',
+            type: 'pdf',
+            size: 0,
             build: 1234
           },
           {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://digital-science.slack.com/archives/C20TZCMMF/p1624355499030500

This PR is flagging broken compiles with an empty output.pdf as a compile failure. This should help in cutting down the noise in sentry (and provide a better UX).

#### Related Issues / PRs

For https://digital-science.slack.com/archives/C20TZCMMF/p1624355499030500

### Review

Some output file fields are optional and they have been copied conditionally from the _internal_ file to the output file object. This complicates writing tests for as `JSON.stringify` is not as strict as `sinon.stub().calledWith` and hence requires special handling for _missing_ field when writing tests (the former drops undefined, the later requires exact matches). To simplify all of this I am now destructing the _internal_ file attributes into the output file entry. This has been done in a separate commit: https://github.com/overleaf/clsi/commit/bbcb97a74cc637b6e6133bc8346f0ab1104520af

#### Potential Impact

Low.
