### PR TITLE
[misc] ContentCacheMetrics: log slow pdf caching performance

### DIFF
--- a/app/js/ContentCacheMetrics.js
+++ b/app/js/ContentCacheMetrics.js
@@ -36,7 +36,7 @@ function emitPdfCachingStats(stats, timings) {
       ? timings.compileE2E /
         (timings.compileE2E - timings['compute-pdf-caching'])
       : 1
-  if (fraction > 1.5) {
+  if (fraction > 1.5 && timings.compileE2E > 10 * 1000) {
     logger.warn(
       {
         stats,

--- a/app/js/ContentCacheMetrics.js
+++ b/app/js/ContentCacheMetrics.js
@@ -30,6 +30,9 @@ function emitPdfStats(stats, timings) {
 function emitPdfCachingStats(stats, timings) {
   if (!stats['pdf-size']) return // double check
 
+  // How much extra time did we spent in PDF.js?
+  Metrics.timing('compute-pdf-caching', timings['compute-pdf-caching'])
+
   // How large is the overhead of hashing up-front?
   const fraction =
     timings.compileE2E - timings['compute-pdf-caching'] !== 0


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3871
For https://digital-science.slack.com/archives/C0216GDEG9L/p1624437084020500

This PR is logging seemingly slow pdf caching performance. It may as well be very fast compiles that show a high overhead.

#### Screenshots

With lowered threshold:
```
clsi_1                    | {"name":"clsi","hostname":"ca2ae0f26e11","pid":46,"level":40,"stats":{"latexmk-errors":0,"latex-runs":1,"latex-runs-with-errors":0,"latex-runs-1":1,"latex-runs-with-errors-1":0,"pdf-size":61957,"pdf-caching-n-ranges":6,"pdf-caching-total-ranges-size":59595,"pdf-caching-n-new-ranges":0,"pdf-caching-new-ranges-size":0,"pdf-caching-reclaimed-space":0},"timings":{"compute-pdf-caching":12,"compile":591,"compileE2E":645},"load":[1.2,1.02,1.02],"msg":"slow pdf caching","time":"2021-06-23T09:58:09.624Z","v":0}
```

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3871
For https://digital-science.slack.com/archives/C0216GDEG9L/p1624437084020500

#### Potential Impact

Low.

#### Manual Testing Performed

- lower threshold and compile, see log line (screenshots section)
- restore threshold and see no log line
