### PR TITLE
[misc] bail out from pdf caching processing after 10s or earlier

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -292,6 +292,8 @@ module.exports = CompileManager = {
                   timings['cpu-time'] / stats['latex-runs']
                 )
               }
+              // Emit compile time.
+              timings.compile = ts
 
               return OutputFileFinder.findOutputFiles(
                 resourceList,
@@ -317,8 +319,7 @@ module.exports = CompileManager = {
                         )
                       }
 
-                      // Emit compile time.
-                      timings.compile = ts
+                      // Emit e2e compile time.
                       timings.compileE2E = timerE2E.done()
 
                       if (stats['pdf-size']) {

--- a/app/js/ContentCacheManager.js
+++ b/app/js/ContentCacheManager.js
@@ -10,27 +10,34 @@ const Settings = require('settings-sharelatex')
 const OError = require('@overleaf/o-error')
 const pLimit = require('p-limit')
 const { parseXrefTable } = require('../lib/pdfjs/parseXrefTable')
+const { TimedOutError } = require('./Errors')
 
 /**
  *
  * @param {String} contentDir path to directory where content hash files are cached
  * @param {String} filePath the pdf file to scan for streams
  * @param {number} size the pdf size
+ * @param {number} compileTime
  */
-async function update(contentDir, filePath, size) {
+async function update(contentDir, filePath, size, compileTime) {
+  const checkDeadline = getDeadlineChecker(compileTime)
   const ranges = []
   const newRanges = []
   // keep track of hashes expire old ones when they reach a generation > N.
   const tracker = await HashFileTracker.from(contentDir)
   tracker.updateAge()
 
-  const rawTable = await parseXrefTable(filePath, size)
+  checkDeadline('after init HashFileTracker')
+
+  const rawTable = await parseXrefTable(filePath, size, checkDeadline)
   rawTable.sort((a, b) => {
     return a.offset - b.offset
   })
   rawTable.forEach((obj, idx) => {
     obj.idx = idx
   })
+
+  checkDeadline('after parsing')
 
   const uncompressedObjects = []
   for (const object of rawTable) {
@@ -50,12 +57,14 @@ async function update(contentDir, filePath, size) {
     if (size < Settings.pdfCachingMinChunkSize) {
       continue
     }
-    uncompressedObjects.push(object)
+    uncompressedObjects.push({ object, idx: uncompressedObjects.length })
   }
+
+  checkDeadline('after finding uncompressed')
 
   const handle = await fs.promises.open(filePath)
   try {
-    for (const object of uncompressedObjects) {
+    for (const { object, idx } of uncompressedObjects) {
       let buffer = Buffer.alloc(object.size, 0)
       const { bytesRead } = await handle.read(
         buffer,
@@ -63,6 +72,7 @@ async function update(contentDir, filePath, size) {
         object.size,
         object.offset
       )
+      checkDeadline('after read ' + idx)
       if (bytesRead !== object.size) {
         throw new OError('could not read full chunk', {
           object,
@@ -80,6 +90,7 @@ async function update(contentDir, filePath, size) {
       buffer = buffer.subarray(objectIdRaw.byteLength)
 
       const hash = pdfStreamHash(buffer)
+      checkDeadline('after hash ' + idx)
       const range = {
         objectId: objectIdRaw.toString(),
         start: object.offset + objectIdRaw.byteLength,
@@ -92,12 +103,15 @@ async function update(contentDir, filePath, size) {
       if (tracker.track(range)) continue
 
       await writePdfStream(contentDir, hash, buffer)
+      checkDeadline('after write ' + idx)
       newRanges.push(range)
     }
   } finally {
     await handle.close()
   }
 
+  // NOTE: Bailing out below does not make sense.
+  //       Let the next compile use the already written ranges.
   const reclaimedSpace = await tracker.deleteStaleHashes(5)
   await tracker.flush()
   return [ranges, newRanges, reclaimedSpace]
@@ -216,6 +230,28 @@ async function writePdfStream(dir, hash, buffer) {
     } catch (_) {
       throw err
     }
+  }
+}
+
+function getDeadlineChecker(compileTime) {
+  const maxOverhead = Math.min(
+    // Adding 10s to a 40s compile time is OK.
+    compileTime / 4,
+    // Adding 30s to a 120s compile time is not OK, limit to 10s.
+    Settings.pdfCachingMaxProcessingTime
+  )
+
+  const deadline = Date.now() + maxOverhead
+  let lastStage = { stage: 'start', now: Date.now() }
+  return function (stage) {
+    const now = Date.now()
+    if (now > deadline) {
+      throw new TimedOutError(stage, {
+        lastStage: lastStage.stage,
+        diffToLastStage: now - lastStage.now
+      })
+    }
+    lastStage = { stage, now }
   }
 }
 

--- a/app/js/ContentCacheManager.js
+++ b/app/js/ContentCacheManager.js
@@ -235,22 +235,26 @@ async function writePdfStream(dir, hash, buffer) {
 
 function getDeadlineChecker(compileTime) {
   const maxOverhead = Math.min(
-    // Adding 10s to a 40s compile time is OK.
-    compileTime / 4,
+    // Adding 10s to a  40s compile time is OK.
+    // Adding  1s to a   3s compile time is OK.
+    Math.max(compileTime / 4, 1000),
     // Adding 30s to a 120s compile time is not OK, limit to 10s.
     Settings.pdfCachingMaxProcessingTime
   )
 
   const deadline = Date.now() + maxOverhead
   let lastStage = { stage: 'start', now: Date.now() }
+  let completedStages = 0
   return function (stage) {
     const now = Date.now()
     if (now > deadline) {
       throw new TimedOutError(stage, {
+        completedStages,
         lastStage: lastStage.stage,
         diffToLastStage: now - lastStage.now
       })
     }
+    completedStages++
     lastStage = { stage, now }
   }
 }

--- a/app/js/ContentCacheMetrics.js
+++ b/app/js/ContentCacheMetrics.js
@@ -19,6 +19,9 @@ function getSystemLoad() {
 const ONE_MB = 1024 * 1024
 
 function emitPdfStats(stats, timings) {
+  if (stats['pdf-caching-timed-out']) {
+    Metrics.inc('pdf-caching-timed-out')
+  }
   if (timings['compute-pdf-caching']) {
     emitPdfCachingStats(stats, timings)
   } else {

--- a/app/js/Errors.js
+++ b/app/js/Errors.js
@@ -4,6 +4,8 @@
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
+const OError = require('@overleaf/o-error')
+
 let Errors
 var NotFoundError = function (message) {
   const error = new Error(message)
@@ -29,7 +31,10 @@ var AlreadyCompilingError = function (message) {
 }
 AlreadyCompilingError.prototype.__proto__ = Error.prototype
 
+class TimedOutError extends OError {}
+
 module.exports = Errors = {
+  TimedOutError,
   NotFoundError,
   FilesOutOfSyncError,
   AlreadyCompilingError

--- a/app/lib/pdfjs/FSPdfManager.js
+++ b/app/lib/pdfjs/FSPdfManager.js
@@ -4,10 +4,10 @@ const { MissingDataException } = require('pdfjs-dist/lib/core/core_utils')
 const { FSStream } = require('./FSStream')
 
 class FSPdfManager extends LocalPdfManager {
-  constructor(docId, options) {
+  constructor(docId, { fh, size, checkDeadline }) {
     const nonEmptyDummyBuffer = Buffer.alloc(1, 0)
     super(docId, nonEmptyDummyBuffer)
-    this.stream = new FSStream(options.fh, 0, options.size)
+    this.stream = new FSStream(fh, 0, size, null, null, checkDeadline)
     this.pdfDocument = new PDFDocument(this, this.stream)
   }
 

--- a/app/lib/pdfjs/parseXrefTable.js
+++ b/app/lib/pdfjs/parseXrefTable.js
@@ -1,18 +1,21 @@
 const fs = require('fs')
 const { FSPdfManager } = require('./FSPdfManager')
 
-async function parseXrefTable(path, size) {
+async function parseXrefTable(path, size, checkDeadline) {
   if (size === 0) {
     return []
   }
 
   const file = await fs.promises.open(path)
   try {
-    const manager = new FSPdfManager(0, { fh: file, size })
+    const manager = new FSPdfManager(0, { fh: file, size, checkDeadline })
 
     await manager.ensureDoc('checkHeader')
+    checkDeadline('pdfjs: after checkHeader')
     await manager.ensureDoc('parseStartXRef')
+    checkDeadline('pdfjs: after parseStartXRef')
     await manager.ensureDoc('parse')
+    checkDeadline('pdfjs: after parse')
     return manager.pdfDocument.catalog.xref.entries
   } finally {
     file.close()

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -68,7 +68,9 @@ module.exports = {
   enablePdfCaching: process.env.ENABLE_PDF_CACHING === 'true',
   enablePdfCachingDark: process.env.ENABLE_PDF_CACHING_DARK === 'true',
   pdfCachingMinChunkSize:
-    parseInt(process.env.PDF_CACHING_MIN_CHUNK_SIZE, 10) || 1024
+    parseInt(process.env.PDF_CACHING_MIN_CHUNK_SIZE, 10) || 1024,
+  pdfCachingMaxProcessingTime:
+    parseInt(process.env.PDF_CACHING_MAX_PROCESSING_TIME, 10) || 10 * 1000
 }
 
 if (process.env.ALLOWED_COMPILE_GROUPS) {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3871

This PR is adding processing deadline to the pdf caching logic. The deadline is 10s or 1/4 of the compile time, what ever is lower. This will allow slow compiles (120s) to use 10s of overhead and a 12s compile at most 3s. We can tweak this later.

#### Screenshots

lower deadline from 10s to 1ms
```
clsi_1                    | {"name":"clsi","hostname":"4bfb59052377","pid":277,"level":40,"err":{"message":"after init HashFileTracker","name":"TimedOutError","stack":"TimedOutError: after init HashFileTracker\n    at /app/app/js/ContentCacheManager.js:249:13\n    at Object.update (/app/app/js/ContentCacheManager.js:30:3)","info":{"lastStage":"start","diffToLastStage":2}},"outputDir":"/app/output/60b0dd39c418bc00598a0d22-5efc543e0c774e0026c8598b","stats":{"latexmk-errors":0,"latex-runs":1,"latex-runs-with-errors":0,"latex-runs-1":1,"latex-runs-with-errors-1":0,"pdf-size":12313},"timings":{"compile":513},"msg":"pdf caching timed out","time":"2021-06-23T13:20:31.145Z","v":0}
```

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3871

### Review

I am ignoring the processing time for clearing and flushing the ranges tracker per the inline comment:

>   // NOTE: Bailing out below does not make sense.
>  //       Let the next compile use the already written ranges.

#### Potential Impact

Low. Errors in caching do not break compiles.

#### Manual Testing Performed

- compile with 10s limit
- compile with 1ms limit
