### PR TITLE
remove output directory for expired projects

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -419,7 +419,12 @@ module.exports = CompileManager = {
         const age = now - stats.mtime
         const hasExpired = age > max_cache_age_ms
         if (hasExpired) {
-          return fse.remove(checkDir, cb)
+          // remove the compile directory and the output directory
+          const outputDir = Path.join(
+            Settings.path.outputDir,
+            Path.basename(checkDir)
+          )
+          return async.eachSeries([checkDir, outputDir], fse.remove, cb)
         } else {
           return cb()
         }


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR removes the output directory for a project when the compile directory is deleted.  This was overlooked when splitting the output directory out from the compile directory.

#### Screenshots



#### Related Issues / PRs

https://github.com/overleaf/clsi/pull/250

### Review

This will remove the output build dirs as well as the object cache for the project+user, so pdf serving after 24 hours won't work.

Looking at the default setting `project_cache_length_ms: 1000 * 60 * 60 * 24` it's not clear that this code ever gets run in production since the instance lifetime is <24 hours.

#### Potential Impact

Project expiry on the clsi

#### Manual Testing Performed

- [X]  Trigger the expiry in the dev env after running the acceptance tests to expire lots of projects (reduce the project_cache_length_ms to 1000 and change the setInterval to a setTimeout of 0 to allow them to be expired.)

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald 