### PR TITLE
[misc] add timings for the sync stage and output stage

### DIFF
--- a/app/js/CompileManager.js
+++ b/app/js/CompileManager.js
@@ -114,7 +114,7 @@ module.exports = CompileManager = {
         },
         'written files to disk'
       )
-      timer.done()
+      const syncStage = timer.done()
 
       const injectDraftModeIfRequired = function (callback) {
         if (request.draft) {
@@ -295,6 +295,8 @@ module.exports = CompileManager = {
               // Emit compile time.
               timings.compile = ts
 
+              timer = new Metrics.Timer('process-output-files')
+
               return OutputFileFinder.findOutputFiles(
                 resourceList,
                 compileDir,
@@ -318,6 +320,10 @@ module.exports = CompileManager = {
                           'failed to save output files'
                         )
                       }
+
+                      const outputStage = timer.done()
+                      timings.sync = syncStage
+                      timings.output = outputStage
 
                       // Emit e2e compile time.
                       timings.compileE2E = timerE2E.done()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4151

This PR is adding two timings for the project file syncing stage and output file copying/processing stage. The clsi-perf service will consume these timings.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4151

#### Potential Impact

Low.

#### Manual Testing Performed
- compile in dev-env

![image](https://user-images.githubusercontent.com/17931887/123952226-9c482a00-d99d-11eb-9a3b-7296e408318a.png)
