### PR TITLE
[UrlFetcher] do not override domain for clsi-perf requests

### DIFF
--- a/app/js/UrlFetcher.js
+++ b/app/js/UrlFetcher.js
@@ -42,9 +42,12 @@ module.exports = UrlFetcher = {
       return (_callback = function () {})
     }
 
-    if (settings.filestoreDomainOveride != null) {
-      const p = URL.parse(url).path
-      url = `${settings.filestoreDomainOveride}${p}`
+    const u = URL.parse(url)
+    if (
+      settings.filestoreDomainOveride &&
+      u.host !== settings.apis.clsiPerf.host
+    ) {
+      url = `${settings.filestoreDomainOveride}${u.path}`
     }
     var timeoutHandler = setTimeout(
       function () {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -51,6 +51,11 @@ module.exports = {
   apis: {
     clsi: {
       url: `http://${process.env.CLSI_HOST || 'localhost'}:3013`
+    },
+    clsiPerf: {
+      host: `${process.env.CLSI_PERF_HOST || 'localhost'}:${
+        process.env.CLSI_PERF_PORT || '3043'
+      }`
     }
   },
 

--- a/test/unit/js/UrlFetcherTests.js
+++ b/test/unit/js/UrlFetcherTests.js
@@ -24,7 +24,13 @@ describe('UrlFetcher', function () {
           defaults: (this.defaults = sinon.stub().returns((this.request = {})))
         },
         fs: (this.fs = {}),
-        'settings-sharelatex': (this.settings = {})
+        'settings-sharelatex': (this.settings = {
+          apis: {
+            clsiPerf: {
+              host: 'localhost:3043'
+            }
+          }
+        })
       }
     }))
   })
@@ -92,6 +98,19 @@ describe('UrlFetcher', function () {
         this.urlStream.emit('response', this.res)
         this.urlStream.emit('end')
         return this.fileStream.emit('finish')
+      })
+
+      it('should not use override clsiPerf domain when filestoreDomainOveride is set', function (done) {
+        this.settings.filestoreDomainOveride = '192.11.11.11'
+        const url = 'http://localhost:3043/file/here?query=string'
+        this.UrlFetcher.pipeUrlToFile(url, this.path, () => {
+          this.request.get.args[0][0].url.should.equal(url)
+          done()
+        })
+        this.res = { statusCode: 200 }
+        this.urlStream.emit('response', this.res)
+        this.urlStream.emit('end')
+        this.fileStream.emit('finish')
       })
 
       return it('should use override domain when filestoreDomainOveride is set', function (done) {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/4151

Checking logs reveled that we forgot to handle the filestore override for clsi-perf downloads. This PR is adding an explicit exception for clsi-perf. 

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/4151

#### Potential Impact

Low, unit/acceptance tests cover this code path.

#### Manual Testing Performed

- add unit test
- clear compile/cache/db dirs and compile a project with images in dev-env