### PR TITLE
[misc] fix sync-to-pdf feature when sibling compiles are disabled

### DIFF
--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -32,7 +32,8 @@ module.exports = {
     outputDir: Path.resolve(__dirname, '../output'),
     clsiCacheDir: Path.resolve(__dirname, '../cache'),
     synctexBaseDir(projectId) {
-      return Path.join(this.compilesDir, projectId)
+      // HACK: The files are referenced as `/COMPILES_DIR/PROJECT_ID/./main.tex` in synctex.
+      return Path.join(this.compilesDir, projectId) + '/.'
     },
   },
 


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Fixes https://github.com/overleaf/overleaf/issues/919
For https://digital-science.slack.com/archives/CM8CT5MUP/p1626769788005200

The project paths are tracked with a `/./` component in the synctex file.
```
SyncTeX Version:1
Input:1:/var/lib/sharelatex/data/compiles/PROJECT_ID/./main.tex
...
```
This was breaking our synctex invocation. This PR is adding the extra compontent.

#### Related Issues / PRs

Fixes https://github.com/overleaf/overleaf/issues/919
For https://digital-science.slack.com/archives/CM8CT5MUP/p1626769788005200

### Review

Sandbox compiles are not affected and tested in CI.

#### Potential Impact

Low.

#### Manual Testing Performed

- build server-ce image and test sync-to-code and sync-to-pdf
  https://console.cloud.google.com/cloud-build/builds;region=global/c7625584-3f3f-4442-b5cc-11e157184bf5?project=overleaf-ops

![image](https://user-images.githubusercontent.com/17931887/126304925-ab363020-24cb-4bc8-a3b5-967cf7675a3a.png)
![image](https://user-images.githubusercontent.com/17931887/126304994-87353dcd-9513-4e35-96f1-d2beda06f11f.png)
