### PR TITLE
[perf] trim down install_deps.sh -- install docker cli only

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,4 +1,24 @@
-/bin/sh
-wget -qO- https://get.docker.com/ | sh
-apt-get install poppler-utils vim ghostscript --yes
-npm rebuild
+#!/bin/bash
+set -ex
+
+apt-get update
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" \
+  > /etc/apt/sources.list.d/docker.list
+apt-get update
+
+apt-get install -y \
+  docker-ce-cli \
+  poppler-utils \
+  ghostscript \
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR is speeding up the builds slightly (~6:30-7:30 -> ~5:30-6:00).
- install docker cli only
- drop vim install

https://console.cloud.google.com/cloud-build/builds?project=overleaf-ops&pageState=(%22builds%22:(%22f%22:%22%255B%257B_22k_22_3A_22Tags_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22clsi_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22tags_22%257D%255D%22))

### Review

Docker install steps were taken from https://docs.docker.com/engine/install/debian/

Bonus: I've added `set -e` for bailing out and deleted the apt-package lists.

#### Potential Impact

Low. We do not invoke docker inside the clsi container in prod for anything important (only a `docker --version` check).

#### Manual Testing Performed

- CI passes